### PR TITLE
Feature/cognito support

### DIFF
--- a/.github/workflows/rspec.yaml
+++ b/.github/workflows/rspec.yaml
@@ -3,23 +3,6 @@ name: cftest
 on: [push, pull_request]
 
 jobs:
-  test:
-    name: test
-    runs-on: ubuntu-latest
-
-    steps:
-    - uses: actions/checkout@v2
-    - name: set up ruby 2.7
-      uses: actions/setup-ruby@v1
-      with:
-        ruby-version: 2.7.x
-    - name: install gems
-      run: gem install cfhighlander rspec 
-    - name: set cfndsl spec
-      run: cfndsl -u
-    - name: cftest
-      run: rspec
-      env:
-        AWS_ACCESS_KEY: ${{ secrets.AWS_ACCESS_KEY }}
-        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-        AWS_REGION: ap-southeast-2
+  rspec:
+    uses: theonestack/shared-workflows/.github/workflows/rspec.yaml@main
+    secrets: inherit

--- a/fargate-v2.cfhighlander.rb
+++ b/fargate-v2.cfhighlander.rb
@@ -2,6 +2,7 @@ CfhighlanderTemplate do
 
   DependsOn 'lib-iam@0.2.0'
   DependsOn 'lib-ec2@0.1.0'
+  DependsOn 'lib-alb@feature/cognito_listener_rules'
   
   Parameters do
     ComponentParam 'EnvironmentName', 'dev', isGlobal: true

--- a/fargate-v2.cfhighlander.rb
+++ b/fargate-v2.cfhighlander.rb
@@ -12,6 +12,9 @@ CfhighlanderTemplate do
     ComponentParam 'SubnetIds', type: 'CommaDelimitedList'
 
     ComponentParam 'EcsCluster'
+    ComponentParam 'UserPoolId', ''
+    ComponentParam 'UserPoolClientId', ''
+    ComponentParam 'UserPoolDomainName', ''
 
     if defined? targetgroup
       ComponentParam 'DnsDomain', isGlobal: true

--- a/fargate-v2.cfhighlander.rb
+++ b/fargate-v2.cfhighlander.rb
@@ -2,7 +2,7 @@ CfhighlanderTemplate do
 
   DependsOn 'lib-iam@0.2.0'
   DependsOn 'lib-ec2@0.1.0'
-  DependsOn 'lib-alb@feature/cognito_listener_rules'
+  DependsOn 'lib-alb'
   
   Parameters do
     ComponentParam 'EnvironmentName', 'dev', isGlobal: true

--- a/fargate-v2.cfndsl.rb
+++ b/fargate-v2.cfndsl.rb
@@ -60,7 +60,7 @@ CloudFormation do
     targetgroups.each do |targetgroup|
       if targetgroup.has_key?('cognito')
         targetgroup['cognito'].each do |cognito_condition|
-          ElasticLoadBalancingV2_ListenerRule(rule_name) do
+          ElasticLoadBalancingV2_ListenerRule("CongitoRule#{targetgroup['resource_name']}") do
             Actions [cognito(self)]
             Conditions generate_fargate_listener_conditions(cognito_condition)
             ListenerArn Ref(targetgroup['listener_resource'])

--- a/fargate-v2.cfndsl.rb
+++ b/fargate-v2.cfndsl.rb
@@ -59,7 +59,7 @@ CloudFormation do
 
     targetgroups.each do |targetgroup|
       if targetgroup.has_key?('cognito')
-        targetgroup['congito'].each do |cognito_condition|
+        targetgroup['cognito'].each do |cognito_condition|
           ElasticLoadBalancingV2_ListenerRule(rule_name) do
             Actions [cognito(self)]
             Conditions generate_fargate_listener_conditions(cognito_condition)

--- a/fargate-v2.cfndsl.rb
+++ b/fargate-v2.cfndsl.rb
@@ -117,7 +117,7 @@ CloudFormation do
           end
 
           actions = []
-          actions << { Type: "forward", TargetGroupArn: Ref(targetgroup['resource_name']) }
+          actions << { Type: "forward", Order: 5000, TargetGroupArn: Ref(targetgroup['resource_name']) }
 
           if targetgroup.has_key?('cognito')
             if targetgroup['cognito'] == true

--- a/fargate-v2.cfndsl.rb
+++ b/fargate-v2.cfndsl.rb
@@ -133,11 +133,11 @@ CloudFormation do
             end
           end
 
-          actions = [{ Type: "forward", Order: 5000, TargetGroupArn: Ref(targetgroup['resource_name']) }]
+          actions = [{ Type: "forward", Order: 5000, TargetGroupArn: Ref(targetgroup['resource_name'])}]
           actions_with_cognito = actions + [cognito(Ref(:UserPoolId), Ref(:UserPoolClientId), Ref(:UserPoolDomainName))]
           
           ElasticLoadBalancingV2_ListenerRule(rule_name) do
-            Actions FnIf(:EnableCognito, actions_with_cognito, actions )
+            Actions FnIf(:EnableCognito, actions_with_cognito, actions)
             Conditions listener_conditions
             ListenerArn Ref(targetgroup['listener_resource'])
             Priority rule['priority']

--- a/fargate-v2.cfndsl.rb
+++ b/fargate-v2.cfndsl.rb
@@ -39,6 +39,8 @@ CloudFormation do
     end
   end
 
+  Condition(:EnableCognito, FnNot(FnEquals(Ref(:UserPoolClientId), '')))
+
   service_loadbalancer = []
   targetgroups = external_parameters.fetch(:targetgroup, {})
   multiplie_target_groups =  targetgroups.is_a?(Array)
@@ -131,17 +133,11 @@ CloudFormation do
             end
           end
 
-          actions = []
-          actions << { Type: "forward", Order: 5000, TargetGroupArn: Ref(targetgroup['resource_name']) }
-
-          if targetgroup.has_key?('cognito')
-            if targetgroup['cognito'] == true
-              actions << cognito(self)
-            end
-          end
-
+          actions = [{ Type: "forward", Order: 5000, TargetGroupArn: Ref(targetgroup['resource_name']) }]
+          actions_with_cognito = actions + [cognito(Ref(:UserPoolId), Ref(:UserPoolClientId), Ref(:UserPoolDomainName))]
+          
           ElasticLoadBalancingV2_ListenerRule(rule_name) do
-            Actions actions
+            Actions FnIf(:EnableCognito, actions_with_cognito, actions )
             Conditions listener_conditions
             ListenerArn Ref(targetgroup['listener_resource'])
             Priority rule['priority']

--- a/fargate-v2.cfndsl.rb
+++ b/fargate-v2.cfndsl.rb
@@ -61,7 +61,7 @@ CloudFormation do
       if targetgroup.has_key?('cognito')
         targetgroup['congito'].each do |cognito_condition|
           ElasticLoadBalancingV2_ListenerRule(rule_name) do
-            Actions [{ Type: "forward", TargetGroupArn: Ref(targetgroup['resource_name']) }]
+            Actions [cognito(self)]
             Conditions generate_fargate_listener_conditions(cognito_condition)
             ListenerArn Ref(targetgroup['listener_resource'])
             Priority 1

--- a/spec/alb_spec.rb
+++ b/spec/alb_spec.rb
@@ -1,63 +1,230 @@
 require 'yaml'
 
-describe 'compiled component' do
+describe 'compiled component fargate-v2' do
   
   context 'cftest' do
     it 'compiles test' do
       expect(system("cfhighlander cftest #{@validate} --tests tests/alb.test.yaml")).to be_truthy
     end      
   end
-
+  
   let(:template) { YAML.load_file("#{File.dirname(__FILE__)}/../out/tests/alb/fargate-v2.compiled.yaml") }
+  
+  context "Resource" do
 
-  context 'Resource TargetGroup' do
-
-    let(:properties) { template["Resources"]["TaskTargetGroup"]["Properties"] }
-
-    it 'has property Properties' do
-      expect(properties).to include({
-        "Port"=>80, 
-        "Protocol"=>"HTTP", 
-        "TargetType"=>"ip", 
-        "VpcId"=>{"Ref"=>"VPCId"}
-      })
-    end
-
-  end
-
-  context 'Resource TargetRule' do
-
-    let(:properties) { template["Resources"]["TargetRule10"]["Properties"] }
-
-    it 'has property Properties' do
-      expect(properties).to eq({
-        "Actions"=>[{"TargetGroupArn"=>{"Ref"=>"TaskTargetGroup"}, "Type"=>"forward"}], 
-        "Conditions"=>[{"Field"=>"host-header", "Values"=>["www.*"]}],
-        "ListenerArn"=>{"Ref"=>"Listener"},
-        "Priority"=>10
-        })
-    end
-
-  end
-
-  context 'check template parameters' do
     
-    let(:parameters) { template["Parameters"] }
+    context "SecurityGroup" do
+      let(:resource) { template["Resources"]["SecurityGroup"] }
 
-    it 'has load balancer params' do
-      expect(parameters).to include({
-        "LoadBalancer" => {"Default"=>"", "NoEcho"=>false, "Type"=>"String"},
-        "DnsDomain" => {"Default"=>"", "NoEcho"=>false, "Type"=>"String"},
-        "Listener" => {"Default"=>"", "NoEcho"=>false, "Type"=>"String"}
-      })
+      it "is of type AWS::EC2::SecurityGroup" do
+          expect(resource["Type"]).to eq("AWS::EC2::SecurityGroup")
+      end
+      
+      it "to have property VpcId" do
+          expect(resource["Properties"]["VpcId"]).to eq({"Ref"=>"VPCId"})
+      end
+      
+      it "to have property GroupDescription" do
+          expect(resource["Properties"]["GroupDescription"]).to eq("fargate-v2 fargate service")
+      end
+      
     end
+    
+    context "TaskTargetGroup" do
+      let(:resource) { template["Resources"]["TaskTargetGroup"] }
 
-    it 'dose not have target group params' do
-      expect(parameters).not_to include({
-        "TargetGroup" => {"Default"=>"", "NoEcho"=>false, "Type"=>"String"}
-      })
+      it "is of type AWS::ElasticLoadBalancingV2::TargetGroup" do
+          expect(resource["Type"]).to eq("AWS::ElasticLoadBalancingV2::TargetGroup")
+      end
+      
+      it "to have property Port" do
+          expect(resource["Properties"]["Port"]).to eq(80)
+      end
+      
+      it "to have property Protocol" do
+          expect(resource["Properties"]["Protocol"]).to eq("HTTP")
+      end
+      
+      it "to have property VpcId" do
+          expect(resource["Properties"]["VpcId"]).to eq({"Ref"=>"VPCId"})
+      end
+      
+      it "to have property TargetType" do
+          expect(resource["Properties"]["TargetType"]).to eq("ip")
+      end
+      
+      it "to have property Tags" do
+          expect(resource["Properties"]["Tags"]).to eq([{"Key"=>"Environment", "Value"=>{"Ref"=>"EnvironmentName"}}, {"Key"=>"EnvironmentType", "Value"=>{"Ref"=>"EnvironmentType"}}])
+      end
+      
     end
+    
+    context "TargetRule10" do
+      let(:resource) { template["Resources"]["TargetRule10"] }
 
+      it "is of type AWS::ElasticLoadBalancingV2::ListenerRule" do
+          expect(resource["Type"]).to eq("AWS::ElasticLoadBalancingV2::ListenerRule")
+      end
+      
+      it "to have property Actions" do
+          expect(resource["Properties"]["Actions"]).to eq({"Fn::If"=>["EnableCognito", [{"Type"=>"forward", "Order"=>5000, "TargetGroupArn"=>{"Ref"=>"TaskTargetGroup"}}, {"Type"=>"authenticate-cognito", "Order"=>1, "AuthenticateCognitoConfig"=>{"UserPoolArn"=>{"Ref"=>"UserPoolId"}, "UserPoolClientId"=>{"Ref"=>"UserPoolClientId"}, "UserPoolDomain"=>{"Ref"=>"UserPoolDomainName"}}}], [{"Type"=>"forward", "Order"=>5000, "TargetGroupArn"=>{"Ref"=>"TaskTargetGroup"}}]]})
+      end
+      
+      it "to have property Conditions" do
+          expect(resource["Properties"]["Conditions"]).to eq([{"Field"=>"host-header", "Values"=>["www.*"]}])
+      end
+      
+      it "to have property ListenerArn" do
+          expect(resource["Properties"]["ListenerArn"]).to eq({"Ref"=>"Listener"})
+      end
+      
+      it "to have property Priority" do
+          expect(resource["Properties"]["Priority"]).to eq(10)
+      end
+      
+    end
+    
+    context "EcsFargateService" do
+      let(:resource) { template["Resources"]["EcsFargateService"] }
+
+      it "is of type AWS::ECS::Service" do
+          expect(resource["Type"]).to eq("AWS::ECS::Service")
+      end
+      
+      it "to have property Cluster" do
+          expect(resource["Properties"]["Cluster"]).to eq({"Ref"=>"EcsCluster"})
+      end
+      
+      it "to have property DesiredCount" do
+          expect(resource["Properties"]["DesiredCount"]).to eq({"Ref"=>"DesiredCount"})
+      end
+      
+      it "to have property DeploymentConfiguration" do
+          expect(resource["Properties"]["DeploymentConfiguration"]).to eq({"MinimumHealthyPercent"=>{"Ref"=>"MinimumHealthyPercent"}, "MaximumPercent"=>{"Ref"=>"MaximumPercent"}})
+      end
+      
+      it "to have property EnableExecuteCommand" do
+          expect(resource["Properties"]["EnableExecuteCommand"]).to eq(false)
+      end
+      
+      it "to have property TaskDefinition" do
+          expect(resource["Properties"]["TaskDefinition"]).to eq({"Ref"=>"Task"})
+      end
+      
+      it "to have property LaunchType" do
+          expect(resource["Properties"]["LaunchType"]).to eq("FARGATE")
+      end
+      
+      it "to have property LoadBalancers" do
+          expect(resource["Properties"]["LoadBalancers"]).to eq([{"ContainerName"=>"nginx", "ContainerPort"=>80, "TargetGroupArn"=>{"Ref"=>"TaskTargetGroup"}}])
+      end
+      
+      it "to have property NetworkConfiguration" do
+          expect(resource["Properties"]["NetworkConfiguration"]).to eq({"AwsvpcConfiguration"=>{"AssignPublicIp"=>"DISABLED", "SecurityGroups"=>[{"Ref"=>"SecurityGroup"}], "Subnets"=>{"Ref"=>"SubnetIds"}}})
+      end
+      
+    end
+    
+    context "LogGroup" do
+      let(:resource) { template["Resources"]["LogGroup"] }
+
+      it "is of type AWS::Logs::LogGroup" do
+          expect(resource["Type"]).to eq("AWS::Logs::LogGroup")
+      end
+      
+      it "to have property LogGroupName" do
+          expect(resource["Properties"]["LogGroupName"]).to eq({"Ref"=>"AWS::StackName"})
+      end
+      
+      it "to have property RetentionInDays" do
+          expect(resource["Properties"]["RetentionInDays"]).to eq("7")
+      end
+      
+    end
+    
+    context "TaskRole" do
+      let(:resource) { template["Resources"]["TaskRole"] }
+
+      it "is of type AWS::IAM::Role" do
+          expect(resource["Type"]).to eq("AWS::IAM::Role")
+      end
+      
+      it "to have property AssumeRolePolicyDocument" do
+          expect(resource["Properties"]["AssumeRolePolicyDocument"]).to eq({"Version"=>"2012-10-17", "Statement"=>[{"Effect"=>"Allow", "Principal"=>{"Service"=>"ecs-tasks.amazonaws.com"}, "Action"=>"sts:AssumeRole"}, {"Effect"=>"Allow", "Principal"=>{"Service"=>"ssm.amazonaws.com"}, "Action"=>"sts:AssumeRole"}]})
+      end
+      
+      it "to have property Path" do
+          expect(resource["Properties"]["Path"]).to eq("/")
+      end
+      
+      it "to have property Policies" do
+          expect(resource["Properties"]["Policies"]).to eq([{"PolicyName"=>"fargate_default_policy", "PolicyDocument"=>{"Statement"=>[{"Sid"=>"fargatedefaultpolicy", "Action"=>["logs:GetLogEvents"], "Resource"=>[{"Fn::GetAtt"=>["LogGroup", "Arn"]}], "Effect"=>"Allow"}]}}])
+      end
+      
+    end
+    
+    context "ExecutionRole" do
+      let(:resource) { template["Resources"]["ExecutionRole"] }
+
+      it "is of type AWS::IAM::Role" do
+          expect(resource["Type"]).to eq("AWS::IAM::Role")
+      end
+      
+      it "to have property AssumeRolePolicyDocument" do
+          expect(resource["Properties"]["AssumeRolePolicyDocument"]).to eq({"Version"=>"2012-10-17", "Statement"=>[{"Effect"=>"Allow", "Principal"=>{"Service"=>"ecs-tasks.amazonaws.com"}, "Action"=>"sts:AssumeRole"}, {"Effect"=>"Allow", "Principal"=>{"Service"=>"ssm.amazonaws.com"}, "Action"=>"sts:AssumeRole"}]})
+      end
+      
+      it "to have property Path" do
+          expect(resource["Properties"]["Path"]).to eq("/")
+      end
+      
+      it "to have property ManagedPolicyArns" do
+          expect(resource["Properties"]["ManagedPolicyArns"]).to eq(["arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"])
+      end
+      
+    end
+    
+    context "Task" do
+      let(:resource) { template["Resources"]["Task"] }
+
+      it "is of type AWS::ECS::TaskDefinition" do
+          expect(resource["Type"]).to eq("AWS::ECS::TaskDefinition")
+      end
+      
+      it "to have property ContainerDefinitions" do
+          expect(resource["Properties"]["ContainerDefinitions"]).to eq([{"Name"=>"proxy", "Image"=>{"Fn::Join"=>["", ["", "nginx", ":", "latest"]]}, "LogConfiguration"=>{"LogDriver"=>"awslogs", "Options"=>{"awslogs-group"=>{"Ref"=>"LogGroup"}, "awslogs-region"=>{"Ref"=>"AWS::Region"}, "awslogs-stream-prefix"=>"proxy"}}, "PortMappings"=>[{"ContainerPort"=>80}]}])
+      end
+      
+      it "to have property RequiresCompatibilities" do
+          expect(resource["Properties"]["RequiresCompatibilities"]).to eq(["FARGATE"])
+      end
+      
+      it "to have property Cpu" do
+          expect(resource["Properties"]["Cpu"]).to eq(256)
+      end
+      
+      it "to have property Memory" do
+          expect(resource["Properties"]["Memory"]).to eq(512)
+      end
+      
+      it "to have property NetworkMode" do
+          expect(resource["Properties"]["NetworkMode"]).to eq("awsvpc")
+      end
+      
+      it "to have property TaskRoleArn" do
+          expect(resource["Properties"]["TaskRoleArn"]).to eq({"Ref"=>"TaskRole"})
+      end
+      
+      it "to have property ExecutionRoleArn" do
+          expect(resource["Properties"]["ExecutionRoleArn"]).to eq({"Ref"=>"ExecutionRole"})
+      end
+      
+      it "to have property Tags" do
+          expect(resource["Properties"]["Tags"]).to eq([{"Key"=>"Name", "Value"=>"fargatev2Task"}, {"Key"=>"Environment", "Value"=>{"Ref"=>"EnvironmentName"}}, {"Key"=>"EnvironmentType", "Value"=>{"Ref"=>"EnvironmentType"}}])
+      end
+      
+    end
+    
   end
 
 end

--- a/spec/circuit_breaker_spec.rb
+++ b/spec/circuit_breaker_spec.rb
@@ -1,6 +1,6 @@
 require 'yaml'
 
-describe 'compiled component' do
+describe 'compiled component fargate-v2' do
   
   context 'cftest' do
     it 'compiles test' do
@@ -9,199 +9,168 @@ describe 'compiled component' do
   end
   
   let(:template) { YAML.load_file("#{File.dirname(__FILE__)}/../out/tests/circuit_breaker/fargate-v2.compiled.yaml") }
+  
+  context "Resource" do
 
-  context 'Resource LogGroup' do
+    
+    context "SecurityGroup" do
+      let(:resource) { template["Resources"]["SecurityGroup"] }
 
-    let(:properties) { template["Resources"]["LogGroup"]["Properties"] }
-
-    it 'has property RetentionInDays' do
-      expect(properties["RetentionInDays"]).to eq('7')
+      it "is of type AWS::EC2::SecurityGroup" do
+          expect(resource["Type"]).to eq("AWS::EC2::SecurityGroup")
+      end
+      
+      it "to have property VpcId" do
+          expect(resource["Properties"]["VpcId"]).to eq({"Ref"=>"VPCId"})
+      end
+      
+      it "to have property GroupDescription" do
+          expect(resource["Properties"]["GroupDescription"]).to eq("fargate-v2 fargate service")
+      end
+      
     end
+    
+    context "EcsFargateService" do
+      let(:resource) { template["Resources"]["EcsFargateService"] }
 
-    it 'has property LogGroupName' do
-      expect(properties["LogGroupName"]).to eq({"Ref"=>"AWS::StackName"})
+      it "is of type AWS::ECS::Service" do
+          expect(resource["Type"]).to eq("AWS::ECS::Service")
+      end
+      
+      it "to have property Cluster" do
+          expect(resource["Properties"]["Cluster"]).to eq({"Ref"=>"EcsCluster"})
+      end
+      
+      it "to have property PlatformVersion" do
+          expect(resource["Properties"]["PlatformVersion"]).to eq("1.4.0")
+      end
+      
+      it "to have property DesiredCount" do
+          expect(resource["Properties"]["DesiredCount"]).to eq({"Ref"=>"DesiredCount"})
+      end
+      
+      it "to have property DeploymentConfiguration" do
+          expect(resource["Properties"]["DeploymentConfiguration"]).to eq({"MinimumHealthyPercent"=>{"Ref"=>"MinimumHealthyPercent"}, "MaximumPercent"=>{"Ref"=>"MaximumPercent"}, "DeploymentCircuitBreaker"=>{"Enable"=>true, "Rollback"=>true}})
+      end
+      
+      it "to have property EnableExecuteCommand" do
+          expect(resource["Properties"]["EnableExecuteCommand"]).to eq(false)
+      end
+      
+      it "to have property TaskDefinition" do
+          expect(resource["Properties"]["TaskDefinition"]).to eq({"Ref"=>"Task"})
+      end
+      
+      it "to have property LaunchType" do
+          expect(resource["Properties"]["LaunchType"]).to eq("FARGATE")
+      end
+      
+      it "to have property NetworkConfiguration" do
+          expect(resource["Properties"]["NetworkConfiguration"]).to eq({"AwsvpcConfiguration"=>{"AssignPublicIp"=>"DISABLED", "SecurityGroups"=>[{"Ref"=>"SecurityGroup"}], "Subnets"=>{"Ref"=>"SubnetIds"}}})
+      end
+      
     end
+    
+    context "LogGroup" do
+      let(:resource) { template["Resources"]["LogGroup"] }
 
+      it "is of type AWS::Logs::LogGroup" do
+          expect(resource["Type"]).to eq("AWS::Logs::LogGroup")
+      end
+      
+      it "to have property LogGroupName" do
+          expect(resource["Properties"]["LogGroupName"]).to eq({"Ref"=>"AWS::StackName"})
+      end
+      
+      it "to have property RetentionInDays" do
+          expect(resource["Properties"]["RetentionInDays"]).to eq("7")
+      end
+      
+    end
+    
+    context "TaskRole" do
+      let(:resource) { template["Resources"]["TaskRole"] }
+
+      it "is of type AWS::IAM::Role" do
+          expect(resource["Type"]).to eq("AWS::IAM::Role")
+      end
+      
+      it "to have property AssumeRolePolicyDocument" do
+          expect(resource["Properties"]["AssumeRolePolicyDocument"]).to eq({"Version"=>"2012-10-17", "Statement"=>[{"Effect"=>"Allow", "Principal"=>{"Service"=>"ecs-tasks.amazonaws.com"}, "Action"=>"sts:AssumeRole"}, {"Effect"=>"Allow", "Principal"=>{"Service"=>"ssm.amazonaws.com"}, "Action"=>"sts:AssumeRole"}]})
+      end
+      
+      it "to have property Path" do
+          expect(resource["Properties"]["Path"]).to eq("/")
+      end
+      
+      it "to have property Policies" do
+          expect(resource["Properties"]["Policies"]).to eq([{"PolicyName"=>"fargate_default_policy", "PolicyDocument"=>{"Statement"=>[{"Sid"=>"fargatedefaultpolicy", "Action"=>["logs:GetLogEvents"], "Resource"=>[{"Fn::GetAtt"=>["LogGroup", "Arn"]}], "Effect"=>"Allow"}]}}])
+      end
+      
+    end
+    
+    context "ExecutionRole" do
+      let(:resource) { template["Resources"]["ExecutionRole"] }
+
+      it "is of type AWS::IAM::Role" do
+          expect(resource["Type"]).to eq("AWS::IAM::Role")
+      end
+      
+      it "to have property AssumeRolePolicyDocument" do
+          expect(resource["Properties"]["AssumeRolePolicyDocument"]).to eq({"Version"=>"2012-10-17", "Statement"=>[{"Effect"=>"Allow", "Principal"=>{"Service"=>"ecs-tasks.amazonaws.com"}, "Action"=>"sts:AssumeRole"}, {"Effect"=>"Allow", "Principal"=>{"Service"=>"ssm.amazonaws.com"}, "Action"=>"sts:AssumeRole"}]})
+      end
+      
+      it "to have property Path" do
+          expect(resource["Properties"]["Path"]).to eq("/")
+      end
+      
+      it "to have property ManagedPolicyArns" do
+          expect(resource["Properties"]["ManagedPolicyArns"]).to eq(["arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"])
+      end
+      
+    end
+    
+    context "Task" do
+      let(:resource) { template["Resources"]["Task"] }
+
+      it "is of type AWS::ECS::TaskDefinition" do
+          expect(resource["Type"]).to eq("AWS::ECS::TaskDefinition")
+      end
+      
+      it "to have property ContainerDefinitions" do
+          expect(resource["Properties"]["ContainerDefinitions"]).to eq([{"Name"=>"proxy", "Image"=>{"Fn::Join"=>["", ["", "nginx", ":", "latest"]]}, "LogConfiguration"=>{"LogDriver"=>"awslogs", "Options"=>{"awslogs-group"=>{"Ref"=>"LogGroup"}, "awslogs-region"=>{"Ref"=>"AWS::Region"}, "awslogs-stream-prefix"=>"proxy"}}}])
+      end
+      
+      it "to have property RequiresCompatibilities" do
+          expect(resource["Properties"]["RequiresCompatibilities"]).to eq(["FARGATE"])
+      end
+      
+      it "to have property Cpu" do
+          expect(resource["Properties"]["Cpu"]).to eq(256)
+      end
+      
+      it "to have property Memory" do
+          expect(resource["Properties"]["Memory"]).to eq(512)
+      end
+      
+      it "to have property NetworkMode" do
+          expect(resource["Properties"]["NetworkMode"]).to eq("awsvpc")
+      end
+      
+      it "to have property TaskRoleArn" do
+          expect(resource["Properties"]["TaskRoleArn"]).to eq({"Ref"=>"TaskRole"})
+      end
+      
+      it "to have property ExecutionRoleArn" do
+          expect(resource["Properties"]["ExecutionRoleArn"]).to eq({"Ref"=>"ExecutionRole"})
+      end
+      
+      it "to have property Tags" do
+          expect(resource["Properties"]["Tags"]).to eq([{"Key"=>"Name", "Value"=>"fargatev2Task"}, {"Key"=>"Environment", "Value"=>{"Ref"=>"EnvironmentName"}}, {"Key"=>"EnvironmentType", "Value"=>{"Ref"=>"EnvironmentType"}}])
+      end
+      
+    end
+    
   end
-
-  context 'Resource Task' do
-
-    let(:properties) { template["Resources"]["Task"]["Properties"] }
-    let(:containerDefinition) { template["Resources"]["Task"]["Properties"]['ContainerDefinitions'][0] }
-
-    it 'has property RequiresCompatibilities' do
-      expect(properties["RequiresCompatibilities"]).to eq(['FARGATE'])
-    end
-
-    it 'has property CPU' do
-      expect(properties["Cpu"]).to eq(256)
-    end
-
-    it 'has property Memory' do
-      expect(properties["Memory"]).to eq(512)
-    end
-
-    it 'has property NetworkMode' do
-      expect(properties["NetworkMode"]).to eq("awsvpc")
-    end
-
-    it 'has property Tags' do
-      expect(properties["Tags"]).to eq([
-        {"Key"=>"Name", "Value"=>"fargatev2Task"}, 
-        {"Key"=>"Environment", "Value"=>{"Ref"=>"EnvironmentName"}}, 
-        {"Key"=>"EnvironmentType", "Value"=>{"Ref"=>"EnvironmentType"}}])
-    end
-
-    it 'has ContainerDefinition Name' do
-      expect(containerDefinition["Name"]).to eq("proxy")
-    end
-
-    it 'has ContainerDefinition Image' do
-      expect(containerDefinition["Image"]).to eq({"Fn::Join"=>["", ["", "nginx", ":", "latest"]]})
-    end
-
-    it 'has ContainerDefinition LogConfiguration' do
-      expect(containerDefinition["LogConfiguration"]["LogDriver"]).to eq("awslogs")
-      expect(containerDefinition["LogConfiguration"]["Options"]).to eq({
-        "awslogs-group" => {"Ref"=>"LogGroup"},
-        "awslogs-region" => {"Ref"=>"AWS::Region"},
-        "awslogs-stream-prefix" => "proxy"
-      })
-
-    end
-
-  end
-
-  context 'Resource Security Group' do
-
-    let(:properties) { template["Resources"]["SecurityGroup"]["Properties"] }
-
-    it 'has property VpcId' do
-      expect(properties["VpcId"]).to eq({"Ref"=>"VPCId"})
-    end
-
-    it 'has property GroupDescription' do
-      expect(properties["GroupDescription"]).to eq("fargate-v2 fargate service")
-    end
-
-  end
-
-  context 'Resource ExecutionRole' do
-
-    let(:properties) { template["Resources"]["ExecutionRole"]['Properties'] }
-
-    it 'has ManagedPolicyArns' do
-      expect(properties["ManagedPolicyArns"]).to eq(["arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"])
-    end
-
-    it 'has AssumeRolePolicyDocument' do
-      expect(properties["AssumeRolePolicyDocument"]).to eq({
-        "Statement"=>[
-          {
-            "Action"=>"sts:AssumeRole", 
-            "Effect"=>"Allow", 
-            "Principal"=>{"Service"=>"ecs-tasks.amazonaws.com"}
-          },
-          {
-            "Action"=>"sts:AssumeRole", 
-            "Effect"=>"Allow", 
-            "Principal"=>{"Service"=>"ssm.amazonaws.com"}
-          }
-        ], 
-        "Version"=>"2012-10-17"
-      })
-    end
-
-  end
-
-  context 'Resource TaskRole' do
-
-    let(:properties) { template["Resources"]["TaskRole"]['Properties'] }
-
-    it 'has AssumeRolePolicyDocument' do
-      expect(properties["AssumeRolePolicyDocument"]).to eq({
-        "Version" => "2012-10-17",
-        "Statement" => [
-          {
-            "Action"=>"sts:AssumeRole",
-            "Effect"=>"Allow",
-            "Principal"=>{"Service"=>"ecs-tasks.amazonaws.com"}
-          },
-          {
-            "Action"=>"sts:AssumeRole",
-            "Effect"=>"Allow",
-            "Principal"=>{"Service"=>"ssm.amazonaws.com"}
-          }
-        ],
-      })
-    end
-
-    it 'has Polices' do
-      expect(properties["Policies"]).to eq([{
-        "PolicyDocument"=>{
-          "Statement"=>[{
-            "Action"=>["logs:GetLogEvents"],
-            "Effect"=>"Allow",
-            "Resource"=>[{"Fn::GetAtt"=>["LogGroup", "Arn"]}],
-            "Sid"=>"fargatedefaultpolicy"}
-          ]},
-          "PolicyName"=>"fargate_default_policy"
-        }]
-      )
-    end
-
-  end
-
-  context 'Resource Service' do
-
-    let(:properties) { template["Resources"]["EcsFargateService"]["Properties"] }
-
-    it 'has property Cluster' do
-      expect(properties["Cluster"]).to eq({"Ref"=>"EcsCluster"})
-    end
-
-    it 'has property LaunchType' do
-      expect(properties["LaunchType"]).to eq("FARGATE")
-    end
-
-    it 'has property DesiredCount' do
-      expect(properties["DesiredCount"]).to eq({"Ref"=>"DesiredCount"})
-    end
-
-    it 'has property DeploymentConfiguration' do
-      expect(properties["DeploymentConfiguration"]).to eq({
-        "MaximumPercent"=>{"Ref"=>"MaximumPercent"}, 
-        "MinimumHealthyPercent"=>{"Ref"=>"MinimumHealthyPercent"},
-        "DeploymentCircuitBreaker" => {"Enable"=>true, "Rollback"=>true}
-      })
-    end
-
-    it 'has property TaskDefinition' do
-      expect(properties["TaskDefinition"]).to eq({"Ref"=>"Task"})
-    end
-
-    it 'has property NetworkConfiguration' do
-      expect(properties["NetworkConfiguration"]).to eq({
-        "AwsvpcConfiguration"=>{
-          "AssignPublicIp"=>"DISABLED", 
-          "SecurityGroups"=>[{"Ref"=>"SecurityGroup"}], 
-          "Subnets"=>{"Ref"=>"SubnetIds"}
-        }
-      })
-    end
-
-  end
-
-  context 'Resource Outputs' do
-
-    let(:outputs) { template["Outputs"] }
-
-    it 'has component_name as part of the export' do
-      expect(outputs['EcsTaskArn']).to eq({
-        "Export"=>{"Name"=>{"Fn::Sub"=>"${EnvironmentName}-fargatev2Task-EcsTaskArn"}},
-        "Value"=>{"Ref"=>"Task"}
-      })
-    end
-  end 
 
 end

--- a/spec/dynamic_priorities_spec.rb
+++ b/spec/dynamic_priorities_spec.rb
@@ -4,11 +4,11 @@ describe 'compiled component fargate-v2' do
   
   context 'cftest' do
     it 'compiles test' do
-      expect(system("cfhighlander cftest #{@validate} --tests tests/existing_target_groups.test.yaml")).to be_truthy
+      expect(system("cfhighlander cftest #{@validate} --tests tests/dynamic_priorities.test.yaml")).to be_truthy
     end      
   end
   
-  let(:template) { YAML.load_file("#{File.dirname(__FILE__)}/../out/tests/existing_target_groups/fargate-v2.compiled.yaml") }
+  let(:template) { YAML.load_file("#{File.dirname(__FILE__)}/../out/tests/dynamic_priorities/fargate-v2.compiled.yaml") }
   
   context "Resource" do
 
@@ -26,6 +26,60 @@ describe 'compiled component fargate-v2' do
       
       it "to have property GroupDescription" do
           expect(resource["Properties"]["GroupDescription"]).to eq("fargate-v2 fargate service")
+      end
+      
+    end
+    
+    context "TaskTargetGroup" do
+      let(:resource) { template["Resources"]["TaskTargetGroup"] }
+
+      it "is of type AWS::ElasticLoadBalancingV2::TargetGroup" do
+          expect(resource["Type"]).to eq("AWS::ElasticLoadBalancingV2::TargetGroup")
+      end
+      
+      it "to have property Port" do
+          expect(resource["Properties"]["Port"]).to eq(80)
+      end
+      
+      it "to have property Protocol" do
+          expect(resource["Properties"]["Protocol"]).to eq("HTTP")
+      end
+      
+      it "to have property VpcId" do
+          expect(resource["Properties"]["VpcId"]).to eq({"Ref"=>"VPCId"})
+      end
+      
+      it "to have property TargetType" do
+          expect(resource["Properties"]["TargetType"]).to eq("ip")
+      end
+      
+      it "to have property Tags" do
+          expect(resource["Properties"]["Tags"]).to eq([{"Key"=>"Environment", "Value"=>{"Ref"=>"EnvironmentName"}}, {"Key"=>"EnvironmentType", "Value"=>{"Ref"=>"EnvironmentType"}}])
+      end
+      
+    end
+    
+    context "TargetRule0" do
+      let(:resource) { template["Resources"]["TargetRule0"] }
+
+      it "is of type AWS::ElasticLoadBalancingV2::ListenerRule" do
+          expect(resource["Type"]).to eq("AWS::ElasticLoadBalancingV2::ListenerRule")
+      end
+      
+      it "to have property Actions" do
+          expect(resource["Properties"]["Actions"]).to eq({"Fn::If"=>["EnableCognito", [{"Type"=>"forward", "Order"=>5000, "TargetGroupArn"=>{"Ref"=>"TaskTargetGroup"}}, {"Type"=>"authenticate-cognito", "Order"=>1, "AuthenticateCognitoConfig"=>{"UserPoolArn"=>{"Ref"=>"UserPoolId"}, "UserPoolClientId"=>{"Ref"=>"UserPoolClientId"}, "UserPoolDomain"=>{"Ref"=>"UserPoolDomainName"}}}], [{"Type"=>"forward", "Order"=>5000, "TargetGroupArn"=>{"Ref"=>"TaskTargetGroup"}}]]})
+      end
+      
+      it "to have property Conditions" do
+          expect(resource["Properties"]["Conditions"]).to eq([{"Field"=>"host-header", "Values"=>["www.*"]}])
+      end
+      
+      it "to have property ListenerArn" do
+          expect(resource["Properties"]["ListenerArn"]).to eq({"Ref"=>"Listener"})
+      end
+      
+      it "to have property Priority" do
+          expect(resource["Properties"]["Priority"]).to eq({"Ref"=>"MinimumHealthyPercent"})
       end
       
     end
@@ -62,7 +116,7 @@ describe 'compiled component fargate-v2' do
       end
       
       it "to have property LoadBalancers" do
-          expect(resource["Properties"]["LoadBalancers"]).to eq([{"ContainerName"=>"nginx", "ContainerPort"=>80, "TargetGroupArn"=>{"Ref"=>"webTargetGroup"}}, {"ContainerName"=>"nginx", "ContainerPort"=>443, "TargetGroupArn"=>{"Ref"=>"secureTargetGroup"}}])
+          expect(resource["Properties"]["LoadBalancers"]).to eq([{"ContainerName"=>"nginx", "ContainerPort"=>80, "TargetGroupArn"=>{"Ref"=>"TaskTargetGroup"}}])
       end
       
       it "to have property NetworkConfiguration" do

--- a/spec/ecs_exec_spec.rb
+++ b/spec/ecs_exec_spec.rb
@@ -1,6 +1,6 @@
 require 'yaml'
 
-describe 'compiled component' do
+describe 'compiled component fargate-v2' do
   
   context 'cftest' do
     it 'compiles test' do
@@ -9,215 +9,168 @@ describe 'compiled component' do
   end
   
   let(:template) { YAML.load_file("#{File.dirname(__FILE__)}/../out/tests/ecs_exec/fargate-v2.compiled.yaml") }
+  
+  context "Resource" do
 
-  context 'Resource LogGroup' do
+    
+    context "SecurityGroup" do
+      let(:resource) { template["Resources"]["SecurityGroup"] }
 
-    let(:properties) { template["Resources"]["LogGroup"]["Properties"] }
-
-    it 'has property RetentionInDays' do
-      expect(properties["RetentionInDays"]).to eq('7')
+      it "is of type AWS::EC2::SecurityGroup" do
+          expect(resource["Type"]).to eq("AWS::EC2::SecurityGroup")
+      end
+      
+      it "to have property VpcId" do
+          expect(resource["Properties"]["VpcId"]).to eq({"Ref"=>"VPCId"})
+      end
+      
+      it "to have property GroupDescription" do
+          expect(resource["Properties"]["GroupDescription"]).to eq("fargate-v2 fargate service")
+      end
+      
     end
+    
+    context "EcsFargateService" do
+      let(:resource) { template["Resources"]["EcsFargateService"] }
 
-    it 'has property LogGroupName' do
-      expect(properties["LogGroupName"]).to eq({"Ref"=>"AWS::StackName"})
+      it "is of type AWS::ECS::Service" do
+          expect(resource["Type"]).to eq("AWS::ECS::Service")
+      end
+      
+      it "to have property Cluster" do
+          expect(resource["Properties"]["Cluster"]).to eq({"Ref"=>"EcsCluster"})
+      end
+      
+      it "to have property PlatformVersion" do
+          expect(resource["Properties"]["PlatformVersion"]).to eq("1.4.0")
+      end
+      
+      it "to have property DesiredCount" do
+          expect(resource["Properties"]["DesiredCount"]).to eq({"Ref"=>"DesiredCount"})
+      end
+      
+      it "to have property DeploymentConfiguration" do
+          expect(resource["Properties"]["DeploymentConfiguration"]).to eq({"MinimumHealthyPercent"=>{"Ref"=>"MinimumHealthyPercent"}, "MaximumPercent"=>{"Ref"=>"MaximumPercent"}})
+      end
+      
+      it "to have property EnableExecuteCommand" do
+          expect(resource["Properties"]["EnableExecuteCommand"]).to eq(true)
+      end
+      
+      it "to have property TaskDefinition" do
+          expect(resource["Properties"]["TaskDefinition"]).to eq({"Ref"=>"Task"})
+      end
+      
+      it "to have property LaunchType" do
+          expect(resource["Properties"]["LaunchType"]).to eq("FARGATE")
+      end
+      
+      it "to have property NetworkConfiguration" do
+          expect(resource["Properties"]["NetworkConfiguration"]).to eq({"AwsvpcConfiguration"=>{"AssignPublicIp"=>"DISABLED", "SecurityGroups"=>[{"Ref"=>"SecurityGroup"}], "Subnets"=>{"Ref"=>"SubnetIds"}}})
+      end
+      
     end
+    
+    context "LogGroup" do
+      let(:resource) { template["Resources"]["LogGroup"] }
 
+      it "is of type AWS::Logs::LogGroup" do
+          expect(resource["Type"]).to eq("AWS::Logs::LogGroup")
+      end
+      
+      it "to have property LogGroupName" do
+          expect(resource["Properties"]["LogGroupName"]).to eq({"Ref"=>"AWS::StackName"})
+      end
+      
+      it "to have property RetentionInDays" do
+          expect(resource["Properties"]["RetentionInDays"]).to eq("7")
+      end
+      
+    end
+    
+    context "TaskRole" do
+      let(:resource) { template["Resources"]["TaskRole"] }
+
+      it "is of type AWS::IAM::Role" do
+          expect(resource["Type"]).to eq("AWS::IAM::Role")
+      end
+      
+      it "to have property AssumeRolePolicyDocument" do
+          expect(resource["Properties"]["AssumeRolePolicyDocument"]).to eq({"Version"=>"2012-10-17", "Statement"=>[{"Effect"=>"Allow", "Principal"=>{"Service"=>"ecs-tasks.amazonaws.com"}, "Action"=>"sts:AssumeRole"}, {"Effect"=>"Allow", "Principal"=>{"Service"=>"ssm.amazonaws.com"}, "Action"=>"sts:AssumeRole"}]})
+      end
+      
+      it "to have property Path" do
+          expect(resource["Properties"]["Path"]).to eq("/")
+      end
+      
+      it "to have property Policies" do
+          expect(resource["Properties"]["Policies"]).to eq([{"PolicyName"=>"fargate_default_policy", "PolicyDocument"=>{"Statement"=>[{"Sid"=>"fargatedefaultpolicy", "Action"=>["logs:GetLogEvents"], "Resource"=>[{"Fn::GetAtt"=>["LogGroup", "Arn"]}], "Effect"=>"Allow"}]}}, {"PolicyName"=>"ssm-session-manager", "PolicyDocument"=>{"Statement"=>[{"Sid"=>"ssmsessionmanager", "Action"=>["ssmmessages:CreateControlChannel", "ssmmessages:CreateDataChannel", "ssmmessages:OpenControlChannel", "ssmmessages:OpenDataChannel"], "Resource"=>["*"], "Effect"=>"Allow"}]}}])
+      end
+      
+    end
+    
+    context "ExecutionRole" do
+      let(:resource) { template["Resources"]["ExecutionRole"] }
+
+      it "is of type AWS::IAM::Role" do
+          expect(resource["Type"]).to eq("AWS::IAM::Role")
+      end
+      
+      it "to have property AssumeRolePolicyDocument" do
+          expect(resource["Properties"]["AssumeRolePolicyDocument"]).to eq({"Version"=>"2012-10-17", "Statement"=>[{"Effect"=>"Allow", "Principal"=>{"Service"=>"ecs-tasks.amazonaws.com"}, "Action"=>"sts:AssumeRole"}, {"Effect"=>"Allow", "Principal"=>{"Service"=>"ssm.amazonaws.com"}, "Action"=>"sts:AssumeRole"}]})
+      end
+      
+      it "to have property Path" do
+          expect(resource["Properties"]["Path"]).to eq("/")
+      end
+      
+      it "to have property ManagedPolicyArns" do
+          expect(resource["Properties"]["ManagedPolicyArns"]).to eq(["arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"])
+      end
+      
+    end
+    
+    context "Task" do
+      let(:resource) { template["Resources"]["Task"] }
+
+      it "is of type AWS::ECS::TaskDefinition" do
+          expect(resource["Type"]).to eq("AWS::ECS::TaskDefinition")
+      end
+      
+      it "to have property ContainerDefinitions" do
+          expect(resource["Properties"]["ContainerDefinitions"]).to eq([{"Name"=>"proxy", "Image"=>{"Fn::Join"=>["", ["", "nginx", ":", "latest"]]}, "LogConfiguration"=>{"LogDriver"=>"awslogs", "Options"=>{"awslogs-group"=>{"Ref"=>"LogGroup"}, "awslogs-region"=>{"Ref"=>"AWS::Region"}, "awslogs-stream-prefix"=>"proxy"}}}])
+      end
+      
+      it "to have property RequiresCompatibilities" do
+          expect(resource["Properties"]["RequiresCompatibilities"]).to eq(["FARGATE"])
+      end
+      
+      it "to have property Cpu" do
+          expect(resource["Properties"]["Cpu"]).to eq(256)
+      end
+      
+      it "to have property Memory" do
+          expect(resource["Properties"]["Memory"]).to eq(512)
+      end
+      
+      it "to have property NetworkMode" do
+          expect(resource["Properties"]["NetworkMode"]).to eq("awsvpc")
+      end
+      
+      it "to have property TaskRoleArn" do
+          expect(resource["Properties"]["TaskRoleArn"]).to eq({"Ref"=>"TaskRole"})
+      end
+      
+      it "to have property ExecutionRoleArn" do
+          expect(resource["Properties"]["ExecutionRoleArn"]).to eq({"Ref"=>"ExecutionRole"})
+      end
+      
+      it "to have property Tags" do
+          expect(resource["Properties"]["Tags"]).to eq([{"Key"=>"Name", "Value"=>"fargatev2Task"}, {"Key"=>"Environment", "Value"=>{"Ref"=>"EnvironmentName"}}, {"Key"=>"EnvironmentType", "Value"=>{"Ref"=>"EnvironmentType"}}])
+      end
+      
+    end
+    
   end
-
-  context 'Resource Task' do
-
-    let(:properties) { template["Resources"]["Task"]["Properties"] }
-    let(:containerDefinition) { template["Resources"]["Task"]["Properties"]['ContainerDefinitions'][0] }
-
-    it 'has property RequiresCompatibilities' do
-      expect(properties["RequiresCompatibilities"]).to eq(['FARGATE'])
-    end
-
-    it 'has property CPU' do
-      expect(properties["Cpu"]).to eq(256)
-    end
-
-    it 'has property Memory' do
-      expect(properties["Memory"]).to eq(512)
-    end
-
-    it 'has property NetworkMode' do
-      expect(properties["NetworkMode"]).to eq("awsvpc")
-    end
-
-    it 'has property Tags' do
-      expect(properties["Tags"]).to eq([
-        {"Key"=>"Name", "Value"=>"fargatev2Task"}, 
-        {"Key"=>"Environment", "Value"=>{"Ref"=>"EnvironmentName"}}, 
-        {"Key"=>"EnvironmentType", "Value"=>{"Ref"=>"EnvironmentType"}}])
-    end
-
-    it 'has ContainerDefinition Name' do
-      expect(containerDefinition["Name"]).to eq("proxy")
-    end
-
-    it 'has ContainerDefinition Image' do
-      expect(containerDefinition["Image"]).to eq({"Fn::Join"=>["", ["", "nginx", ":", "latest"]]})
-    end
-
-    it 'has ContainerDefinition LogConfiguration' do
-      expect(containerDefinition["LogConfiguration"]["LogDriver"]).to eq("awslogs")
-      expect(containerDefinition["LogConfiguration"]["Options"]).to eq({
-        "awslogs-group" => {"Ref"=>"LogGroup"},
-        "awslogs-region" => {"Ref"=>"AWS::Region"},
-        "awslogs-stream-prefix" => "proxy"
-      })
-
-    end
-
-  end
-
-  context 'Resource Security Group' do
-
-    let(:properties) { template["Resources"]["SecurityGroup"]["Properties"] }
-
-    it 'has property VpcId' do
-      expect(properties["VpcId"]).to eq({"Ref"=>"VPCId"})
-    end
-
-    it 'has property GroupDescription' do
-      expect(properties["GroupDescription"]).to eq("fargate-v2 fargate service")
-    end
-
-  end
-
-  context 'Resource ExecutionRole' do
-
-    let(:properties) { template["Resources"]["ExecutionRole"]['Properties'] }
-
-    it 'has ManagedPolicyArns' do
-      expect(properties["ManagedPolicyArns"]).to eq(["arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"])
-    end
-
-    it 'has AssumeRolePolicyDocument' do
-      expect(properties["AssumeRolePolicyDocument"]).to eq({
-        "Statement"=>[
-          {
-            "Action"=>"sts:AssumeRole", 
-            "Effect"=>"Allow", 
-            "Principal"=>{"Service"=>"ecs-tasks.amazonaws.com"}
-          },
-          {
-            "Action"=>"sts:AssumeRole", 
-            "Effect"=>"Allow", 
-            "Principal"=>{"Service"=>"ssm.amazonaws.com"}
-          }
-        ], 
-        "Version"=>"2012-10-17"
-      })
-    end
-
-  end
-
-  context 'Resource TaskRole' do
-
-    let(:properties) { template["Resources"]["TaskRole"]['Properties'] }
-
-    it 'has AssumeRolePolicyDocument' do
-      expect(properties["AssumeRolePolicyDocument"]).to eq({
-        "Version" => "2012-10-17",
-        "Statement" => [
-          {
-            "Action"=>"sts:AssumeRole",
-            "Effect"=>"Allow",
-            "Principal"=>{"Service"=>"ecs-tasks.amazonaws.com"}
-          },
-          {
-            "Action"=>"sts:AssumeRole",
-            "Effect"=>"Allow",
-            "Principal"=>{"Service"=>"ssm.amazonaws.com"}
-          }
-        ],
-      })
-    end
-
-    it 'has Polices' do
-      expect(properties["Policies"]).to eq([
-        {
-          "PolicyDocument"=>{
-            "Statement"=>[{
-              "Action"=>["logs:GetLogEvents"],
-              "Effect"=>"Allow",
-              "Resource"=>[{"Fn::GetAtt"=>["LogGroup", "Arn"]}],
-              "Sid"=>"fargatedefaultpolicy"}
-            ]},
-            "PolicyName"=>"fargate_default_policy"
-        },
-        {
-          "PolicyName" => "ssm-session-manager",
-          "PolicyDocument" => {
-            "Statement" => [{
-              "Sid" => "ssmsessionmanager",
-              "Effect" => "Allow",
-              "Action" => [
-                "ssmmessages:CreateControlChannel",
-                "ssmmessages:CreateDataChannel",
-                "ssmmessages:OpenControlChannel",
-                "ssmmessages:OpenDataChannel"
-              ],
-              "Resource" => ["*"],
-            }]
-          }
-        }
-      ])
-    end
-
-  end
-
-  context 'Resource Service' do
-
-    let(:properties) { template["Resources"]["EcsFargateService"]["Properties"] }
-
-    it 'has property Cluster' do
-      expect(properties["Cluster"]).to eq({"Ref"=>"EcsCluster"})
-    end
-
-    it 'has property LaunchType' do
-      expect(properties["LaunchType"]).to eq("FARGATE")
-    end
-
-    it 'has property DesiredCount' do
-      expect(properties["DesiredCount"]).to eq({"Ref"=>"DesiredCount"})
-    end
-
-    it 'has property DeploymentConfiguration' do
-      expect(properties["DeploymentConfiguration"]).to eq({
-        "MaximumPercent"=>{"Ref"=>"MaximumPercent"}, 
-        "MinimumHealthyPercent"=>{"Ref"=>"MinimumHealthyPercent"}
-      })
-    end
-
-    it 'has property TaskDefinition' do
-      expect(properties["TaskDefinition"]).to eq({"Ref"=>"Task"})
-    end
-
-    it 'has property NetworkConfiguration' do
-      expect(properties["NetworkConfiguration"]).to eq({
-        "AwsvpcConfiguration"=>{
-          "AssignPublicIp"=>"DISABLED", 
-          "SecurityGroups"=>[{"Ref"=>"SecurityGroup"}], 
-          "Subnets"=>{"Ref"=>"SubnetIds"}
-        }
-      })
-    end
-
-  end
-
-  context 'Resource Outputs' do
-
-    let(:outputs) { template["Outputs"] }
-
-    it 'has component_name as part of the export' do
-      expect(outputs['EcsTaskArn']).to eq({
-        "Export"=>{"Name"=>{"Fn::Sub"=>"${EnvironmentName}-fargatev2Task-EcsTaskArn"}},
-        "Value"=>{"Ref"=>"Task"}
-      })
-    end
-  end 
 
 end

--- a/spec/ecs_scaling_spec.rb
+++ b/spec/ecs_scaling_spec.rb
@@ -1,6 +1,6 @@
 require 'yaml'
 
-describe 'compiled component' do
+describe 'compiled component fargate-v2' do
   
   context 'cftest' do
     it 'compiles test' do
@@ -9,131 +9,370 @@ describe 'compiled component' do
   end
   
   let(:template) { YAML.load_file("#{File.dirname(__FILE__)}/../out/tests/ecs_scaling/fargate-v2.compiled.yaml") }
+  
+  context "Resource" do
 
-  context 'Resource LogGroup' do
+    
+    context "SecurityGroup" do
+      let(:resource) { template["Resources"]["SecurityGroup"] }
 
-    let(:properties) { template["Resources"]["LogGroup"]["Properties"] }
-
-    it 'has property RetentionInDays' do
-      expect(properties["RetentionInDays"]).to eq('7')
+      it "is of type AWS::EC2::SecurityGroup" do
+          expect(resource["Type"]).to eq("AWS::EC2::SecurityGroup")
+      end
+      
+      it "to have property VpcId" do
+          expect(resource["Properties"]["VpcId"]).to eq({"Ref"=>"VPCId"})
+      end
+      
+      it "to have property GroupDescription" do
+          expect(resource["Properties"]["GroupDescription"]).to eq("fargate-v2 fargate service")
+      end
+      
     end
+    
+    context "EcsFargateService" do
+      let(:resource) { template["Resources"]["EcsFargateService"] }
 
-    it 'has property LogGroupName' do
-      expect(properties["LogGroupName"]).to eq({"Ref"=>"AWS::StackName"})
+      it "is of type AWS::ECS::Service" do
+          expect(resource["Type"]).to eq("AWS::ECS::Service")
+      end
+      
+      it "to have property Cluster" do
+          expect(resource["Properties"]["Cluster"]).to eq({"Ref"=>"EcsCluster"})
+      end
+      
+      it "to have property PlatformVersion" do
+          expect(resource["Properties"]["PlatformVersion"]).to eq("1.4.0")
+      end
+      
+      it "to have property DesiredCount" do
+          expect(resource["Properties"]["DesiredCount"]).to eq({"Ref"=>"DesiredCount"})
+      end
+      
+      it "to have property DeploymentConfiguration" do
+          expect(resource["Properties"]["DeploymentConfiguration"]).to eq({"MinimumHealthyPercent"=>{"Ref"=>"MinimumHealthyPercent"}, "MaximumPercent"=>{"Ref"=>"MaximumPercent"}})
+      end
+      
+      it "to have property EnableExecuteCommand" do
+          expect(resource["Properties"]["EnableExecuteCommand"]).to eq(false)
+      end
+      
+      it "to have property TaskDefinition" do
+          expect(resource["Properties"]["TaskDefinition"]).to eq({"Ref"=>"Task"})
+      end
+      
+      it "to have property LaunchType" do
+          expect(resource["Properties"]["LaunchType"]).to eq("FARGATE")
+      end
+      
+      it "to have property NetworkConfiguration" do
+          expect(resource["Properties"]["NetworkConfiguration"]).to eq({"AwsvpcConfiguration"=>{"AssignPublicIp"=>"DISABLED", "SecurityGroups"=>[{"Ref"=>"SecurityGroup"}], "Subnets"=>{"Ref"=>"SubnetIds"}}})
+      end
+      
     end
+    
+    context "LogGroup" do
+      let(:resource) { template["Resources"]["LogGroup"] }
 
+      it "is of type AWS::Logs::LogGroup" do
+          expect(resource["Type"]).to eq("AWS::Logs::LogGroup")
+      end
+      
+      it "to have property LogGroupName" do
+          expect(resource["Properties"]["LogGroupName"]).to eq({"Ref"=>"AWS::StackName"})
+      end
+      
+      it "to have property RetentionInDays" do
+          expect(resource["Properties"]["RetentionInDays"]).to eq("7")
+      end
+      
+    end
+    
+    context "TaskRole" do
+      let(:resource) { template["Resources"]["TaskRole"] }
+
+      it "is of type AWS::IAM::Role" do
+          expect(resource["Type"]).to eq("AWS::IAM::Role")
+      end
+      
+      it "to have property AssumeRolePolicyDocument" do
+          expect(resource["Properties"]["AssumeRolePolicyDocument"]).to eq({"Version"=>"2012-10-17", "Statement"=>[{"Effect"=>"Allow", "Principal"=>{"Service"=>"ecs-tasks.amazonaws.com"}, "Action"=>"sts:AssumeRole"}, {"Effect"=>"Allow", "Principal"=>{"Service"=>"ssm.amazonaws.com"}, "Action"=>"sts:AssumeRole"}]})
+      end
+      
+      it "to have property Path" do
+          expect(resource["Properties"]["Path"]).to eq("/")
+      end
+      
+      it "to have property Policies" do
+          expect(resource["Properties"]["Policies"]).to eq([{"PolicyName"=>"fargate_default_policy", "PolicyDocument"=>{"Statement"=>[{"Sid"=>"fargatedefaultpolicy", "Action"=>["logs:GetLogEvents"], "Resource"=>[{"Fn::GetAtt"=>["LogGroup", "Arn"]}], "Effect"=>"Allow"}]}}])
+      end
+      
+    end
+    
+    context "ExecutionRole" do
+      let(:resource) { template["Resources"]["ExecutionRole"] }
+
+      it "is of type AWS::IAM::Role" do
+          expect(resource["Type"]).to eq("AWS::IAM::Role")
+      end
+      
+      it "to have property AssumeRolePolicyDocument" do
+          expect(resource["Properties"]["AssumeRolePolicyDocument"]).to eq({"Version"=>"2012-10-17", "Statement"=>[{"Effect"=>"Allow", "Principal"=>{"Service"=>"ecs-tasks.amazonaws.com"}, "Action"=>"sts:AssumeRole"}, {"Effect"=>"Allow", "Principal"=>{"Service"=>"ssm.amazonaws.com"}, "Action"=>"sts:AssumeRole"}]})
+      end
+      
+      it "to have property Path" do
+          expect(resource["Properties"]["Path"]).to eq("/")
+      end
+      
+      it "to have property ManagedPolicyArns" do
+          expect(resource["Properties"]["ManagedPolicyArns"]).to eq(["arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"])
+      end
+      
+    end
+    
+    context "Task" do
+      let(:resource) { template["Resources"]["Task"] }
+
+      it "is of type AWS::ECS::TaskDefinition" do
+          expect(resource["Type"]).to eq("AWS::ECS::TaskDefinition")
+      end
+      
+      it "to have property ContainerDefinitions" do
+          expect(resource["Properties"]["ContainerDefinitions"]).to eq([{"Name"=>"proxy", "Image"=>{"Fn::Join"=>["", ["", "nginx", ":", "latest"]]}, "LogConfiguration"=>{"LogDriver"=>"awslogs", "Options"=>{"awslogs-group"=>{"Ref"=>"LogGroup"}, "awslogs-region"=>{"Ref"=>"AWS::Region"}, "awslogs-stream-prefix"=>"proxy"}}}])
+      end
+      
+      it "to have property RequiresCompatibilities" do
+          expect(resource["Properties"]["RequiresCompatibilities"]).to eq(["FARGATE"])
+      end
+      
+      it "to have property Cpu" do
+          expect(resource["Properties"]["Cpu"]).to eq(256)
+      end
+      
+      it "to have property Memory" do
+          expect(resource["Properties"]["Memory"]).to eq(512)
+      end
+      
+      it "to have property NetworkMode" do
+          expect(resource["Properties"]["NetworkMode"]).to eq("awsvpc")
+      end
+      
+      it "to have property TaskRoleArn" do
+          expect(resource["Properties"]["TaskRoleArn"]).to eq({"Ref"=>"TaskRole"})
+      end
+      
+      it "to have property ExecutionRoleArn" do
+          expect(resource["Properties"]["ExecutionRoleArn"]).to eq({"Ref"=>"ExecutionRole"})
+      end
+      
+      it "to have property Tags" do
+          expect(resource["Properties"]["Tags"]).to eq([{"Key"=>"Name", "Value"=>"fargatev2Task"}, {"Key"=>"Environment", "Value"=>{"Ref"=>"EnvironmentName"}}, {"Key"=>"EnvironmentType", "Value"=>{"Ref"=>"EnvironmentType"}}])
+      end
+      
+    end
+    
+    context "ServiceECSAutoScaleRole" do
+      let(:resource) { template["Resources"]["ServiceECSAutoScaleRole"] }
+
+      it "is of type AWS::IAM::Role" do
+          expect(resource["Type"]).to eq("AWS::IAM::Role")
+      end
+      
+      it "to have property AssumeRolePolicyDocument" do
+          expect(resource["Properties"]["AssumeRolePolicyDocument"]).to eq({"Version"=>"2012-10-17", "Statement"=>[{"Effect"=>"Allow", "Principal"=>{"Service"=>"application-autoscaling.amazonaws.com"}, "Action"=>"sts:AssumeRole"}]})
+      end
+      
+      it "to have property Path" do
+          expect(resource["Properties"]["Path"]).to eq("/")
+      end
+      
+      it "to have property Policies" do
+          expect(resource["Properties"]["Policies"]).to eq([{"PolicyName"=>"ecs-scaling", "PolicyDocument"=>{"Statement"=>[{"Effect"=>"Allow", "Action"=>["cloudwatch:DescribeAlarms", "cloudwatch:PutMetricAlarm", "cloudwatch:DeleteAlarms"], "Resource"=>"*"}, {"Effect"=>"Allow", "Action"=>["ecs:UpdateService", "ecs:DescribeServices"], "Resource"=>{"Ref"=>"EcsFargateService"}}]}}])
+      end
+      
+    end
+    
+    context "ServiceScalingTarget" do
+      let(:resource) { template["Resources"]["ServiceScalingTarget"] }
+
+      it "is of type AWS::ApplicationAutoScaling::ScalableTarget" do
+          expect(resource["Type"]).to eq("AWS::ApplicationAutoScaling::ScalableTarget")
+      end
+      
+      it "to have property MaxCapacity" do
+          expect(resource["Properties"]["MaxCapacity"]).to eq({"Ref"=>"fargatev2ScalingMax"})
+      end
+      
+      it "to have property MinCapacity" do
+          expect(resource["Properties"]["MinCapacity"]).to eq({"Ref"=>"fargatev2ScalingMin"})
+      end
+      
+      it "to have property ResourceId" do
+          expect(resource["Properties"]["ResourceId"]).to eq({"Fn::Join"=>["", ["service/", {"Fn::Select"=>[1, {"Fn::Split"=>["/", {"Ref"=>"EcsFargateService"}]}]}, "/", {"Fn::Select"=>[2, {"Fn::Split"=>["/", {"Ref"=>"EcsFargateService"}]}]}]]})
+      end
+      
+      it "to have property RoleARN" do
+          expect(resource["Properties"]["RoleARN"]).to eq({"Fn::GetAtt"=>["ServiceECSAutoScaleRole", "Arn"]})
+      end
+      
+      it "to have property ScalableDimension" do
+          expect(resource["Properties"]["ScalableDimension"]).to eq("ecs:service:DesiredCount")
+      end
+      
+      it "to have property ServiceNamespace" do
+          expect(resource["Properties"]["ServiceNamespace"]).to eq("ecs")
+      end
+      
+    end
+    
+    context "ServiceScalingUpPolicy" do
+      let(:resource) { template["Resources"]["ServiceScalingUpPolicy"] }
+
+      it "is of type AWS::ApplicationAutoScaling::ScalingPolicy" do
+          expect(resource["Type"]).to eq("AWS::ApplicationAutoScaling::ScalingPolicy")
+      end
+      
+      it "to have property PolicyName" do
+          expect(resource["Properties"]["PolicyName"]).to eq({"Fn::Join"=>["-", [{"Ref"=>"EnvironmentName"}, "autoscaling", "scale-up-policy"]]})
+      end
+      
+      it "to have property PolicyType" do
+          expect(resource["Properties"]["PolicyType"]).to eq("StepScaling")
+      end
+      
+      it "to have property ScalingTargetId" do
+          expect(resource["Properties"]["ScalingTargetId"]).to eq({"Ref"=>"ServiceScalingTarget"})
+      end
+      
+      it "to have property StepScalingPolicyConfiguration" do
+          expect(resource["Properties"]["StepScalingPolicyConfiguration"]).to eq({"AdjustmentType"=>"ChangeInCapacity", "Cooldown"=>150, "MetricAggregationType"=>"Average", "StepAdjustments"=>[{"ScalingAdjustment"=>"2", "MetricIntervalLowerBound"=>0}]})
+      end
+      
+    end
+    
+    context "ServiceScaleUpAlarm" do
+      let(:resource) { template["Resources"]["ServiceScaleUpAlarm"] }
+
+      it "is of type AWS::CloudWatch::Alarm" do
+          expect(resource["Type"]).to eq("AWS::CloudWatch::Alarm")
+      end
+      
+      it "to have property AlarmDescription" do
+          expect(resource["Properties"]["AlarmDescription"]).to eq({"Fn::Join"=>[" ", [{"Ref"=>"EnvironmentName"}, "autoscaling ecs scale up alarm"]]})
+      end
+      
+      it "to have property MetricName" do
+          expect(resource["Properties"]["MetricName"]).to eq("CPUUtilization")
+      end
+      
+      it "to have property Namespace" do
+          expect(resource["Properties"]["Namespace"]).to eq("AWS/ECS")
+      end
+      
+      it "to have property Statistic" do
+          expect(resource["Properties"]["Statistic"]).to eq("Average")
+      end
+      
+      it "to have property Period" do
+          expect(resource["Properties"]["Period"]).to eq("60")
+      end
+      
+      it "to have property EvaluationPeriods" do
+          expect(resource["Properties"]["EvaluationPeriods"]).to eq("5")
+      end
+      
+      it "to have property Threshold" do
+          expect(resource["Properties"]["Threshold"]).to eq("70")
+      end
+      
+      it "to have property AlarmActions" do
+          expect(resource["Properties"]["AlarmActions"]).to eq([{"Ref"=>"ServiceScalingUpPolicy"}])
+      end
+      
+      it "to have property ComparisonOperator" do
+          expect(resource["Properties"]["ComparisonOperator"]).to eq("GreaterThanThreshold")
+      end
+      
+      it "to have property Dimensions" do
+          expect(resource["Properties"]["Dimensions"]).to eq([{"Name"=>"ServiceName", "Value"=>{"Fn::Select"=>[2, {"Fn::Split"=>["/", {"Ref"=>"EcsFargateService"}]}]}}, {"Name"=>"ClusterName", "Value"=>{"Fn::Select"=>[1, {"Fn::Split"=>["/", {"Ref"=>"EcsFargateService"}]}]}}])
+      end
+      
+    end
+    
+    context "ServiceScalingDownPolicy" do
+      let(:resource) { template["Resources"]["ServiceScalingDownPolicy"] }
+
+      it "is of type AWS::ApplicationAutoScaling::ScalingPolicy" do
+          expect(resource["Type"]).to eq("AWS::ApplicationAutoScaling::ScalingPolicy")
+      end
+      
+      it "to have property PolicyName" do
+          expect(resource["Properties"]["PolicyName"]).to eq({"Fn::Join"=>["-", [{"Ref"=>"EnvironmentName"}, "autoscaling", "scale-down-policy"]]})
+      end
+      
+      it "to have property PolicyType" do
+          expect(resource["Properties"]["PolicyType"]).to eq("StepScaling")
+      end
+      
+      it "to have property ScalingTargetId" do
+          expect(resource["Properties"]["ScalingTargetId"]).to eq({"Ref"=>"ServiceScalingTarget"})
+      end
+      
+      it "to have property StepScalingPolicyConfiguration" do
+          expect(resource["Properties"]["StepScalingPolicyConfiguration"]).to eq({"AdjustmentType"=>"ChangeInCapacity", "Cooldown"=>600, "MetricAggregationType"=>"Average", "StepAdjustments"=>[{"ScalingAdjustment"=>"-1", "MetricIntervalUpperBound"=>0}]})
+      end
+      
+    end
+    
+    context "ServiceScaleDownAlarm" do
+      let(:resource) { template["Resources"]["ServiceScaleDownAlarm"] }
+
+      it "is of type AWS::CloudWatch::Alarm" do
+          expect(resource["Type"]).to eq("AWS::CloudWatch::Alarm")
+      end
+      
+      it "to have property AlarmDescription" do
+          expect(resource["Properties"]["AlarmDescription"]).to eq({"Fn::Join"=>[" ", [{"Ref"=>"EnvironmentName"}, "autoscaling ecs scale down alarm"]]})
+      end
+      
+      it "to have property MetricName" do
+          expect(resource["Properties"]["MetricName"]).to eq("CPUUtilization")
+      end
+      
+      it "to have property Namespace" do
+          expect(resource["Properties"]["Namespace"]).to eq("AWS/ECS")
+      end
+      
+      it "to have property Statistic" do
+          expect(resource["Properties"]["Statistic"]).to eq("Average")
+      end
+      
+      it "to have property Period" do
+          expect(resource["Properties"]["Period"]).to eq("60")
+      end
+      
+      it "to have property EvaluationPeriods" do
+          expect(resource["Properties"]["EvaluationPeriods"]).to eq("5")
+      end
+      
+      it "to have property Threshold" do
+          expect(resource["Properties"]["Threshold"]).to eq("70")
+      end
+      
+      it "to have property AlarmActions" do
+          expect(resource["Properties"]["AlarmActions"]).to eq([{"Ref"=>"ServiceScalingDownPolicy"}])
+      end
+      
+      it "to have property ComparisonOperator" do
+          expect(resource["Properties"]["ComparisonOperator"]).to eq("LessThanThreshold")
+      end
+      
+      it "to have property Dimensions" do
+          expect(resource["Properties"]["Dimensions"]).to eq([{"Name"=>"ServiceName", "Value"=>{"Fn::Select"=>[2, {"Fn::Split"=>["/", {"Ref"=>"EcsFargateService"}]}]}}, {"Name"=>"ClusterName", "Value"=>{"Fn::Select"=>[1, {"Fn::Split"=>["/", {"Ref"=>"EcsFargateService"}]}]}}])
+      end
+      
+    end
+    
   end
 
-  context 'Resource IAM Role' do
-    let(:properties) { template["Resources"]["ServiceECSAutoScaleRole"]["Properties"] }
-
-    it 'has property AssumeRolePolicyDocument' do
-        expect(properties["AssumeRolePolicyDocument"]).to eq(
-          {"Statement"=>[{"Action"=>"sts:AssumeRole", "Effect"=>"Allow", "Principal"=>{"Service"=>"application-autoscaling.amazonaws.com"}}], "Version"=>"2012-10-17"}
-        )
-    end
-
-    it 'has property Policies' do
-        expect(properties["Policies"]).to eq([{
-          "PolicyDocument"=> {
-              "Statement"=> [
-                {
-                  "Action"=> [
-                    "cloudwatch:DescribeAlarms",
-                    "cloudwatch:PutMetricAlarm",
-                    "cloudwatch:DeleteAlarms"
-                  ],
-                  "Effect"=>"Allow",
-                  "Resource"=>"*"
-                },
-                {
-                  "Action"=>["ecs:UpdateService", "ecs:DescribeServices"],
-                  "Effect"=>"Allow",
-                  "Resource"=>{"Ref"=>"EcsFargateService"}
-                }
-              ]
-            },
-            "PolicyName"=>"ecs-scaling"
-        }])
-    end
-  end
-
-  context 'Resource ServiceScalingTarget' do
-    let(:properties) { template["Resources"]["ServiceScalingTarget"]["Properties"] }
-
-    it 'has properties' do
-      expect(properties).to eq({
-        "MaxCapacity" => {"Ref"=>"fargatev2ScalingMax"},
-        "MinCapacity" => {"Ref"=>"fargatev2ScalingMin"},
-        "ResourceId" => {"Fn::Join"=>["", ["service/", {"Fn::Select"=>[1, {"Fn::Split"=>["/", {"Ref"=>"EcsFargateService"}]}]}, "/", {"Fn::Select"=>[2, {"Fn::Split"=>["/", {"Ref"=>"EcsFargateService"}]}]}]]},
-        "RoleARN" => {"Fn::GetAtt"=>["ServiceECSAutoScaleRole", "Arn"]},
-        "ScalableDimension" => "ecs:service:DesiredCount",
-        "ServiceNamespace" => "ecs",
-      })
-    end
-  end
-
-  context 'Resource ServiceScalingUpPolicy' do
-    let(:properties) { template["Resources"]["ServiceScalingUpPolicy"]["Properties"] }
-
-    it 'has properties' do
-      expect(properties).to eq({
-        "PolicyName" => {"Fn::Join"=>["-", [{"Ref"=>"EnvironmentName"}, "autoscaling", "scale-up-policy"]]},
-        "PolicyType" => "StepScaling",
-        "ScalingTargetId" => {"Ref"=>"ServiceScalingTarget"},
-        "StepScalingPolicyConfiguration" => {"AdjustmentType"=>"ChangeInCapacity", "Cooldown"=>150, "MetricAggregationType"=>"Average", "StepAdjustments"=>[{"MetricIntervalLowerBound"=>0, "ScalingAdjustment"=>"2"}]},
-      })
-    end
-  end
-
-  context 'Resource ServiceScaleUpAlarm' do
-    let(:properties) { template["Resources"]["ServiceScaleUpAlarm"]["Properties"] }
-
-    it 'has properties' do
-      expect(properties).to eq({
-        "AlarmActions" => [{"Ref"=>"ServiceScalingUpPolicy"}],
-        "AlarmDescription" => {"Fn::Join"=>[" ", [{"Ref"=>"EnvironmentName"}, "autoscaling ecs scale up alarm"]]},
-        "ComparisonOperator" => "GreaterThanThreshold",
-        "Dimensions" => [{"Name"=>"ServiceName", "Value"=>{"Fn::Select"=>[2, {"Fn::Split"=>["/", {"Ref"=>"EcsFargateService"}]}]}}, {"Name"=>"ClusterName", "Value"=>{"Fn::Select"=>[1, {"Fn::Split"=>["/", {"Ref"=>"EcsFargateService"}]}]}}],
-        "EvaluationPeriods" => "5",
-        "MetricName" => "CPUUtilization",
-        "Namespace" => "AWS/ECS",
-        "Period" => "60",
-        "Statistic" => "Average",
-        "Threshold" => "70",
-      })
-    end
-  end
-
-  context 'Resource ServiceScalingDownPolicy' do
-    let(:properties) { template["Resources"]["ServiceScalingDownPolicy"]["Properties"] }
-
-    it 'has properties' do
-      expect(properties).to eq({
-        "PolicyName" => {"Fn::Join"=>["-", [{"Ref"=>"EnvironmentName"}, "autoscaling", "scale-down-policy"]]},
-        "PolicyType" => "StepScaling",
-        "ScalingTargetId" => {"Ref"=>"ServiceScalingTarget"},
-        "StepScalingPolicyConfiguration" => {"AdjustmentType"=>"ChangeInCapacity", "Cooldown"=>600, "MetricAggregationType"=>"Average", "StepAdjustments"=>[{"MetricIntervalUpperBound"=>0, "ScalingAdjustment"=>"-1"}]},
-      })
-    end
-  end
-
-  context 'Resource ServiceScaleDownAlarm' do
-    let(:properties) { template["Resources"]["ServiceScaleDownAlarm"]["Properties"] }
-
-    it 'has properties' do
-      expect(properties).to eq({
-        "AlarmActions" => [{"Ref"=>"ServiceScalingDownPolicy"}],
-        "AlarmDescription" => {"Fn::Join"=>[" ", [{"Ref"=>"EnvironmentName"}, "autoscaling ecs scale down alarm"]]},
-        "ComparisonOperator" => "LessThanThreshold",
-        "Dimensions" => [{"Name"=>"ServiceName", "Value"=>{"Fn::Select"=>[2, {"Fn::Split"=>["/", {"Ref"=>"EcsFargateService"}]}]}}, {"Name"=>"ClusterName", "Value"=>{"Fn::Select"=>[1, {"Fn::Split"=>["/", {"Ref"=>"EcsFargateService"}]}]}}],
-        "EvaluationPeriods" => "5",
-        "MetricName" => "CPUUtilization",
-        "Namespace" => "AWS/ECS",
-        "Period" => "60",
-        "Statistic" => "Average",
-        "Threshold" => "70",
-      })
-    end
-  end
 end

--- a/spec/multiple_target_groups_spec.rb
+++ b/spec/multiple_target_groups_spec.rb
@@ -1,79 +1,284 @@
 require 'yaml'
 
-describe 'compiled component' do
+describe 'compiled component fargate-v2' do
   
   context 'cftest' do
     it 'compiles test' do
       expect(system("cfhighlander cftest #{@validate} --tests tests/multiple_target_groups.test.yaml")).to be_truthy
-    end
+    end      
   end
-
+  
   let(:template) { YAML.load_file("#{File.dirname(__FILE__)}/../out/tests/multiple_target_groups/fargate-v2.compiled.yaml") }
+  
+  context "Resource" do
 
-  context 'Resource Web TargetGroup' do
-    let(:properties) { template["Resources"]["webTargetGroup"]["Properties"] }
+    
+    context "SecurityGroup" do
+      let(:resource) { template["Resources"]["SecurityGroup"] }
 
-    it 'has a web target group' do
-      expect(properties).to eq({
-        "Port" => 80,
-        "Protocol" => "HTTP",
-        "Tags" => [{"Key"=>"Environment", "Value"=>{"Ref"=>"EnvironmentName"}}, {"Key"=>"EnvironmentType", "Value"=>{"Ref"=>"EnvironmentType"}}],
-        "TargetType" => "ip",
-        "VpcId" => {"Ref"=>"VPCId"},
-      })
+      it "is of type AWS::EC2::SecurityGroup" do
+          expect(resource["Type"]).to eq("AWS::EC2::SecurityGroup")
+      end
+      
+      it "to have property VpcId" do
+          expect(resource["Properties"]["VpcId"]).to eq({"Ref"=>"VPCId"})
+      end
+      
+      it "to have property GroupDescription" do
+          expect(resource["Properties"]["GroupDescription"]).to eq("fargate-v2 fargate service")
+      end
+      
     end
-  end
+    
+    context "webTargetGroup" do
+      let(:resource) { template["Resources"]["webTargetGroup"] }
 
-  context 'Resource Secure TargetGroup' do
-    let(:properties) { template["Resources"]["secureTargetGroup"]["Properties"] }
-
-    it 'has a secure target group' do
-      expect(properties).to eq({
-        "Port" => 443,
-        "Protocol" => "HTTP",
-        "Tags" => [{"Key"=>"Environment", "Value"=>{"Ref"=>"EnvironmentName"}}, {"Key"=>"EnvironmentType", "Value"=>{"Ref"=>"EnvironmentType"}}],
-        "TargetType" => "ip",
-        "VpcId" => {"Ref"=>"VPCId"},
-      })
+      it "is of type AWS::ElasticLoadBalancingV2::TargetGroup" do
+          expect(resource["Type"]).to eq("AWS::ElasticLoadBalancingV2::TargetGroup")
+      end
+      
+      it "to have property Port" do
+          expect(resource["Properties"]["Port"]).to eq(80)
+      end
+      
+      it "to have property Protocol" do
+          expect(resource["Properties"]["Protocol"]).to eq("HTTP")
+      end
+      
+      it "to have property VpcId" do
+          expect(resource["Properties"]["VpcId"]).to eq({"Ref"=>"VPCId"})
+      end
+      
+      it "to have property TargetType" do
+          expect(resource["Properties"]["TargetType"]).to eq("ip")
+      end
+      
+      it "to have property Tags" do
+          expect(resource["Properties"]["Tags"]).to eq([{"Key"=>"Environment", "Value"=>{"Ref"=>"EnvironmentName"}}, {"Key"=>"EnvironmentType", "Value"=>{"Ref"=>"EnvironmentType"}}])
+      end
+      
     end
-  end
+    
+    context "webTargetRule10" do
+      let(:resource) { template["Resources"]["webTargetRule10"] }
 
-  context 'has web listener rule' do
-    let(:parameters) { template["Parameters"] }
-    let(:properties) { template["Resources"]["webTargetRule10"]["Properties"] }
-
-    it 'has a web listener rule' do
-      expect(parameters).to include({
-        "DnsDomain" => {"Default"=>"", "NoEcho"=>false, "Type"=>"String"},
-        "httpListener" => {"Default"=>"", "NoEcho"=>false, "Type"=>"String"},
-      })
-
-      expect(properties).to eq({
-        "Actions" => [{"TargetGroupArn"=>{"Ref"=>"webTargetGroup"}, "Type"=>"forward"}],
-        "Conditions" => [{"Field"=>"host-header", "Values"=>["www.*"]}],
-        "ListenerArn" => {"Ref"=>"httpListener"},
-        "Priority" => 10,
-      })
+      it "is of type AWS::ElasticLoadBalancingV2::ListenerRule" do
+          expect(resource["Type"]).to eq("AWS::ElasticLoadBalancingV2::ListenerRule")
+      end
+      
+      it "to have property Actions" do
+          expect(resource["Properties"]["Actions"]).to eq({"Fn::If"=>["EnableCognito", [{"Type"=>"forward", "Order"=>5000, "TargetGroupArn"=>{"Ref"=>"webTargetGroup"}}, {"Type"=>"authenticate-cognito", "Order"=>1, "AuthenticateCognitoConfig"=>{"UserPoolArn"=>{"Ref"=>"UserPoolId"}, "UserPoolClientId"=>{"Ref"=>"UserPoolClientId"}, "UserPoolDomain"=>{"Ref"=>"UserPoolDomainName"}}}], [{"Type"=>"forward", "Order"=>5000, "TargetGroupArn"=>{"Ref"=>"webTargetGroup"}}]]})
+      end
+      
+      it "to have property Conditions" do
+          expect(resource["Properties"]["Conditions"]).to eq([{"Field"=>"host-header", "Values"=>["www.*"]}])
+      end
+      
+      it "to have property ListenerArn" do
+          expect(resource["Properties"]["ListenerArn"]).to eq({"Ref"=>"httpListener"})
+      end
+      
+      it "to have property Priority" do
+          expect(resource["Properties"]["Priority"]).to eq(10)
+      end
+      
     end
-  end
+    
+    context "secureTargetGroup" do
+      let(:resource) { template["Resources"]["secureTargetGroup"] }
 
-  context 'has secure listener rule' do
-    let(:parameters) { template["Parameters"] }
-    let(:properties) { template["Resources"]["secureTargetRule10"]["Properties"] }
-
-    it 'has a web listener rule' do
-      expect(parameters).to include({
-        "DnsDomain" => {"Default"=>"", "NoEcho"=>false, "Type"=>"String"},
-        "httpListener" => {"Default"=>"", "NoEcho"=>false, "Type"=>"String"},
-      })
-
-      expect(properties).to eq({
-        "Actions" => [{"TargetGroupArn"=>{"Ref"=>"secureTargetGroup"}, "Type"=>"forward"}],
-        "Conditions" => [{"Field"=>"host-header", "Values"=>["www.*"]}],
-        "ListenerArn" => {"Ref"=>"httpsListener"},
-        "Priority" => 10,
-      })
+      it "is of type AWS::ElasticLoadBalancingV2::TargetGroup" do
+          expect(resource["Type"]).to eq("AWS::ElasticLoadBalancingV2::TargetGroup")
+      end
+      
+      it "to have property Port" do
+          expect(resource["Properties"]["Port"]).to eq(443)
+      end
+      
+      it "to have property Protocol" do
+          expect(resource["Properties"]["Protocol"]).to eq("HTTP")
+      end
+      
+      it "to have property VpcId" do
+          expect(resource["Properties"]["VpcId"]).to eq({"Ref"=>"VPCId"})
+      end
+      
+      it "to have property TargetType" do
+          expect(resource["Properties"]["TargetType"]).to eq("ip")
+      end
+      
+      it "to have property Tags" do
+          expect(resource["Properties"]["Tags"]).to eq([{"Key"=>"Environment", "Value"=>{"Ref"=>"EnvironmentName"}}, {"Key"=>"EnvironmentType", "Value"=>{"Ref"=>"EnvironmentType"}}])
+      end
+      
     end
+    
+    context "secureTargetRule10" do
+      let(:resource) { template["Resources"]["secureTargetRule10"] }
+
+      it "is of type AWS::ElasticLoadBalancingV2::ListenerRule" do
+          expect(resource["Type"]).to eq("AWS::ElasticLoadBalancingV2::ListenerRule")
+      end
+      
+      it "to have property Actions" do
+          expect(resource["Properties"]["Actions"]).to eq({"Fn::If"=>["EnableCognito", [{"Type"=>"forward", "Order"=>5000, "TargetGroupArn"=>{"Ref"=>"secureTargetGroup"}}, {"Type"=>"authenticate-cognito", "Order"=>1, "AuthenticateCognitoConfig"=>{"UserPoolArn"=>{"Ref"=>"UserPoolId"}, "UserPoolClientId"=>{"Ref"=>"UserPoolClientId"}, "UserPoolDomain"=>{"Ref"=>"UserPoolDomainName"}}}], [{"Type"=>"forward", "Order"=>5000, "TargetGroupArn"=>{"Ref"=>"secureTargetGroup"}}]]})
+      end
+      
+      it "to have property Conditions" do
+          expect(resource["Properties"]["Conditions"]).to eq([{"Field"=>"host-header", "Values"=>["www.*"]}])
+      end
+      
+      it "to have property ListenerArn" do
+          expect(resource["Properties"]["ListenerArn"]).to eq({"Ref"=>"httpsListener"})
+      end
+      
+      it "to have property Priority" do
+          expect(resource["Properties"]["Priority"]).to eq(10)
+      end
+      
+    end
+    
+    context "EcsFargateService" do
+      let(:resource) { template["Resources"]["EcsFargateService"] }
+
+      it "is of type AWS::ECS::Service" do
+          expect(resource["Type"]).to eq("AWS::ECS::Service")
+      end
+      
+      it "to have property Cluster" do
+          expect(resource["Properties"]["Cluster"]).to eq({"Ref"=>"EcsCluster"})
+      end
+      
+      it "to have property DesiredCount" do
+          expect(resource["Properties"]["DesiredCount"]).to eq({"Ref"=>"DesiredCount"})
+      end
+      
+      it "to have property DeploymentConfiguration" do
+          expect(resource["Properties"]["DeploymentConfiguration"]).to eq({"MinimumHealthyPercent"=>{"Ref"=>"MinimumHealthyPercent"}, "MaximumPercent"=>{"Ref"=>"MaximumPercent"}})
+      end
+      
+      it "to have property EnableExecuteCommand" do
+          expect(resource["Properties"]["EnableExecuteCommand"]).to eq(false)
+      end
+      
+      it "to have property TaskDefinition" do
+          expect(resource["Properties"]["TaskDefinition"]).to eq({"Ref"=>"Task"})
+      end
+      
+      it "to have property LaunchType" do
+          expect(resource["Properties"]["LaunchType"]).to eq("FARGATE")
+      end
+      
+      it "to have property LoadBalancers" do
+          expect(resource["Properties"]["LoadBalancers"]).to eq([{"ContainerName"=>"nginx", "ContainerPort"=>80, "TargetGroupArn"=>{"Ref"=>"webTargetGroup"}}, {"ContainerName"=>"nginx", "ContainerPort"=>443, "TargetGroupArn"=>{"Ref"=>"secureTargetGroup"}}])
+      end
+      
+      it "to have property NetworkConfiguration" do
+          expect(resource["Properties"]["NetworkConfiguration"]).to eq({"AwsvpcConfiguration"=>{"AssignPublicIp"=>"DISABLED", "SecurityGroups"=>[{"Ref"=>"SecurityGroup"}], "Subnets"=>{"Ref"=>"SubnetIds"}}})
+      end
+      
+    end
+    
+    context "LogGroup" do
+      let(:resource) { template["Resources"]["LogGroup"] }
+
+      it "is of type AWS::Logs::LogGroup" do
+          expect(resource["Type"]).to eq("AWS::Logs::LogGroup")
+      end
+      
+      it "to have property LogGroupName" do
+          expect(resource["Properties"]["LogGroupName"]).to eq({"Ref"=>"AWS::StackName"})
+      end
+      
+      it "to have property RetentionInDays" do
+          expect(resource["Properties"]["RetentionInDays"]).to eq("7")
+      end
+      
+    end
+    
+    context "TaskRole" do
+      let(:resource) { template["Resources"]["TaskRole"] }
+
+      it "is of type AWS::IAM::Role" do
+          expect(resource["Type"]).to eq("AWS::IAM::Role")
+      end
+      
+      it "to have property AssumeRolePolicyDocument" do
+          expect(resource["Properties"]["AssumeRolePolicyDocument"]).to eq({"Version"=>"2012-10-17", "Statement"=>[{"Effect"=>"Allow", "Principal"=>{"Service"=>"ecs-tasks.amazonaws.com"}, "Action"=>"sts:AssumeRole"}, {"Effect"=>"Allow", "Principal"=>{"Service"=>"ssm.amazonaws.com"}, "Action"=>"sts:AssumeRole"}]})
+      end
+      
+      it "to have property Path" do
+          expect(resource["Properties"]["Path"]).to eq("/")
+      end
+      
+      it "to have property Policies" do
+          expect(resource["Properties"]["Policies"]).to eq([{"PolicyName"=>"fargate_default_policy", "PolicyDocument"=>{"Statement"=>[{"Sid"=>"fargatedefaultpolicy", "Action"=>["logs:GetLogEvents"], "Resource"=>[{"Fn::GetAtt"=>["LogGroup", "Arn"]}], "Effect"=>"Allow"}]}}])
+      end
+      
+    end
+    
+    context "ExecutionRole" do
+      let(:resource) { template["Resources"]["ExecutionRole"] }
+
+      it "is of type AWS::IAM::Role" do
+          expect(resource["Type"]).to eq("AWS::IAM::Role")
+      end
+      
+      it "to have property AssumeRolePolicyDocument" do
+          expect(resource["Properties"]["AssumeRolePolicyDocument"]).to eq({"Version"=>"2012-10-17", "Statement"=>[{"Effect"=>"Allow", "Principal"=>{"Service"=>"ecs-tasks.amazonaws.com"}, "Action"=>"sts:AssumeRole"}, {"Effect"=>"Allow", "Principal"=>{"Service"=>"ssm.amazonaws.com"}, "Action"=>"sts:AssumeRole"}]})
+      end
+      
+      it "to have property Path" do
+          expect(resource["Properties"]["Path"]).to eq("/")
+      end
+      
+      it "to have property ManagedPolicyArns" do
+          expect(resource["Properties"]["ManagedPolicyArns"]).to eq(["arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"])
+      end
+      
+    end
+    
+    context "Task" do
+      let(:resource) { template["Resources"]["Task"] }
+
+      it "is of type AWS::ECS::TaskDefinition" do
+          expect(resource["Type"]).to eq("AWS::ECS::TaskDefinition")
+      end
+      
+      it "to have property ContainerDefinitions" do
+          expect(resource["Properties"]["ContainerDefinitions"]).to eq([{"Name"=>"proxy", "Image"=>{"Fn::Join"=>["", ["", "nginx", ":", "latest"]]}, "LogConfiguration"=>{"LogDriver"=>"awslogs", "Options"=>{"awslogs-group"=>{"Ref"=>"LogGroup"}, "awslogs-region"=>{"Ref"=>"AWS::Region"}, "awslogs-stream-prefix"=>"proxy"}}, "PortMappings"=>[{"ContainerPort"=>80}]}])
+      end
+      
+      it "to have property RequiresCompatibilities" do
+          expect(resource["Properties"]["RequiresCompatibilities"]).to eq(["FARGATE"])
+      end
+      
+      it "to have property Cpu" do
+          expect(resource["Properties"]["Cpu"]).to eq(256)
+      end
+      
+      it "to have property Memory" do
+          expect(resource["Properties"]["Memory"]).to eq(512)
+      end
+      
+      it "to have property NetworkMode" do
+          expect(resource["Properties"]["NetworkMode"]).to eq("awsvpc")
+      end
+      
+      it "to have property TaskRoleArn" do
+          expect(resource["Properties"]["TaskRoleArn"]).to eq({"Ref"=>"TaskRole"})
+      end
+      
+      it "to have property ExecutionRoleArn" do
+          expect(resource["Properties"]["ExecutionRoleArn"]).to eq({"Ref"=>"ExecutionRole"})
+      end
+      
+      it "to have property Tags" do
+          expect(resource["Properties"]["Tags"]).to eq([{"Key"=>"Name", "Value"=>"fargatev2Task"}, {"Key"=>"Environment", "Value"=>{"Ref"=>"EnvironmentName"}}, {"Key"=>"EnvironmentType", "Value"=>{"Ref"=>"EnvironmentType"}}])
+      end
+      
+    end
+    
   end
 
 end

--- a/spec/secrets_spec.rb
+++ b/spec/secrets_spec.rb
@@ -1,6 +1,6 @@
 require 'yaml'
 
-describe 'compiled component' do
+describe 'compiled component fargate-v2' do
   
   context 'cftest' do
     it 'compiles test' do
@@ -9,47 +9,168 @@ describe 'compiled component' do
   end
   
   let(:template) { YAML.load_file("#{File.dirname(__FILE__)}/../out/tests/secrets/fargate-v2.compiled.yaml") }
+  
+  context "Resource" do
 
-  context 'Resource ExecutionRole' do
     
-    let(:polices) { template["Resources"]["ExecutionRole"]['Properties']['Policies'] }
+    context "SecurityGroup" do
+      let(:resource) { template["Resources"]["SecurityGroup"] }
 
-    it 'has policies restricting access to secrets' do
-      expect(polices).to eq([{
-        "PolicyDocument"=> {
-          "Statement"=> [{
-            "Action"=>"ssm:GetParameters",
-            "Effect"=>"Allow",
-            "Resource"=>[
-              {"Fn::Sub"=>"arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${EnvironmentName}/app/MY_SECRET"},
-              "arn:aws:ssm:eu-central-1:012345678990:parameter/app/YOUR_SECRET"
-            ],
-            "Sid"=>"ssmsecrets"
-          }]
-        },
-        "PolicyName"=>"ssm-secrets"
-      }])
+      it "is of type AWS::EC2::SecurityGroup" do
+          expect(resource["Type"]).to eq("AWS::EC2::SecurityGroup")
+      end
+      
+      it "to have property VpcId" do
+          expect(resource["Properties"]["VpcId"]).to eq({"Ref"=>"VPCId"})
+      end
+      
+      it "to have property GroupDescription" do
+          expect(resource["Properties"]["GroupDescription"]).to eq("fargate-v2 fargate service")
+      end
+      
     end
+    
+    context "EcsFargateService" do
+      let(:resource) { template["Resources"]["EcsFargateService"] }
 
-  end
-
-  context 'Resource Task' do
-
-    let(:secrets) { template["Resources"]["Task"]['Properties']['ContainerDefinitions'][0]['Secrets'] }
-
-    it 'has secrets with arns' do
-      expect(secrets).to eq([
-        {
-          "Name"=>"MY_SECRET",
-          "ValueFrom"=>{"Fn::Sub"=>"arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${EnvironmentName}/app/MY_SECRET"}
-        },
-        {
-          "Name"=>"YOUR_SECRET",
-          "ValueFrom"=>"arn:aws:ssm:eu-central-1:012345678990:parameter/app/YOUR_SECRET"
-        }
-      ])
+      it "is of type AWS::ECS::Service" do
+          expect(resource["Type"]).to eq("AWS::ECS::Service")
+      end
+      
+      it "to have property Cluster" do
+          expect(resource["Properties"]["Cluster"]).to eq({"Ref"=>"EcsCluster"})
+      end
+      
+      it "to have property DesiredCount" do
+          expect(resource["Properties"]["DesiredCount"]).to eq({"Ref"=>"DesiredCount"})
+      end
+      
+      it "to have property DeploymentConfiguration" do
+          expect(resource["Properties"]["DeploymentConfiguration"]).to eq({"MinimumHealthyPercent"=>{"Ref"=>"MinimumHealthyPercent"}, "MaximumPercent"=>{"Ref"=>"MaximumPercent"}})
+      end
+      
+      it "to have property EnableExecuteCommand" do
+          expect(resource["Properties"]["EnableExecuteCommand"]).to eq(false)
+      end
+      
+      it "to have property TaskDefinition" do
+          expect(resource["Properties"]["TaskDefinition"]).to eq({"Ref"=>"Task"})
+      end
+      
+      it "to have property LaunchType" do
+          expect(resource["Properties"]["LaunchType"]).to eq("FARGATE")
+      end
+      
+      it "to have property NetworkConfiguration" do
+          expect(resource["Properties"]["NetworkConfiguration"]).to eq({"AwsvpcConfiguration"=>{"AssignPublicIp"=>"DISABLED", "SecurityGroups"=>[{"Ref"=>"SecurityGroup"}], "Subnets"=>{"Ref"=>"SubnetIds"}}})
+      end
+      
     end
+    
+    context "LogGroup" do
+      let(:resource) { template["Resources"]["LogGroup"] }
 
+      it "is of type AWS::Logs::LogGroup" do
+          expect(resource["Type"]).to eq("AWS::Logs::LogGroup")
+      end
+      
+      it "to have property LogGroupName" do
+          expect(resource["Properties"]["LogGroupName"]).to eq({"Ref"=>"AWS::StackName"})
+      end
+      
+      it "to have property RetentionInDays" do
+          expect(resource["Properties"]["RetentionInDays"]).to eq("7")
+      end
+      
+    end
+    
+    context "TaskRole" do
+      let(:resource) { template["Resources"]["TaskRole"] }
+
+      it "is of type AWS::IAM::Role" do
+          expect(resource["Type"]).to eq("AWS::IAM::Role")
+      end
+      
+      it "to have property AssumeRolePolicyDocument" do
+          expect(resource["Properties"]["AssumeRolePolicyDocument"]).to eq({"Version"=>"2012-10-17", "Statement"=>[{"Effect"=>"Allow", "Principal"=>{"Service"=>"ecs-tasks.amazonaws.com"}, "Action"=>"sts:AssumeRole"}, {"Effect"=>"Allow", "Principal"=>{"Service"=>"ssm.amazonaws.com"}, "Action"=>"sts:AssumeRole"}]})
+      end
+      
+      it "to have property Path" do
+          expect(resource["Properties"]["Path"]).to eq("/")
+      end
+      
+      it "to have property Policies" do
+          expect(resource["Properties"]["Policies"]).to eq([{"PolicyName"=>"fargate_default_policy", "PolicyDocument"=>{"Statement"=>[{"Sid"=>"fargatedefaultpolicy", "Action"=>["logs:GetLogEvents"], "Resource"=>[{"Fn::GetAtt"=>["LogGroup", "Arn"]}], "Effect"=>"Allow"}]}}])
+      end
+      
+    end
+    
+    context "ExecutionRole" do
+      let(:resource) { template["Resources"]["ExecutionRole"] }
+
+      it "is of type AWS::IAM::Role" do
+          expect(resource["Type"]).to eq("AWS::IAM::Role")
+      end
+      
+      it "to have property AssumeRolePolicyDocument" do
+          expect(resource["Properties"]["AssumeRolePolicyDocument"]).to eq({"Version"=>"2012-10-17", "Statement"=>[{"Effect"=>"Allow", "Principal"=>{"Service"=>"ecs-tasks.amazonaws.com"}, "Action"=>"sts:AssumeRole"}, {"Effect"=>"Allow", "Principal"=>{"Service"=>"ssm.amazonaws.com"}, "Action"=>"sts:AssumeRole"}]})
+      end
+      
+      it "to have property Path" do
+          expect(resource["Properties"]["Path"]).to eq("/")
+      end
+      
+      it "to have property ManagedPolicyArns" do
+          expect(resource["Properties"]["ManagedPolicyArns"]).to eq(["arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"])
+      end
+      
+      it "to have property Policies" do
+          expect(resource["Properties"]["Policies"]).to eq([{"PolicyName"=>"ssm-secrets", "PolicyDocument"=>{"Statement"=>[{"Sid"=>"ssmsecrets", "Action"=>"ssm:GetParameters", "Resource"=>[{"Fn::Sub"=>"arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${EnvironmentName}/app/MY_SECRET"}, "arn:aws:ssm:eu-central-1:012345678990:parameter/app/YOUR_SECRET"], "Effect"=>"Allow"}]}}])
+      end
+      
+    end
+    
+    context "Task" do
+      let(:resource) { template["Resources"]["Task"] }
+
+      it "is of type AWS::ECS::TaskDefinition" do
+          expect(resource["Type"]).to eq("AWS::ECS::TaskDefinition")
+      end
+      
+      it "to have property ContainerDefinitions" do
+          expect(resource["Properties"]["ContainerDefinitions"]).to eq([{"Name"=>"proxy", "Image"=>{"Fn::Join"=>["", ["", "nginx", ":", "latest"]]}, "LogConfiguration"=>{"LogDriver"=>"awslogs", "Options"=>{"awslogs-group"=>{"Ref"=>"LogGroup"}, "awslogs-region"=>{"Ref"=>"AWS::Region"}, "awslogs-stream-prefix"=>"proxy"}}, "Secrets"=>[{"Name"=>"MY_SECRET", "ValueFrom"=>{"Fn::Sub"=>"arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${EnvironmentName}/app/MY_SECRET"}}, {"Name"=>"YOUR_SECRET", "ValueFrom"=>"arn:aws:ssm:eu-central-1:012345678990:parameter/app/YOUR_SECRET"}]}])
+      end
+      
+      it "to have property RequiresCompatibilities" do
+          expect(resource["Properties"]["RequiresCompatibilities"]).to eq(["FARGATE"])
+      end
+      
+      it "to have property Cpu" do
+          expect(resource["Properties"]["Cpu"]).to eq(256)
+      end
+      
+      it "to have property Memory" do
+          expect(resource["Properties"]["Memory"]).to eq(512)
+      end
+      
+      it "to have property NetworkMode" do
+          expect(resource["Properties"]["NetworkMode"]).to eq("awsvpc")
+      end
+      
+      it "to have property TaskRoleArn" do
+          expect(resource["Properties"]["TaskRoleArn"]).to eq({"Ref"=>"TaskRole"})
+      end
+      
+      it "to have property ExecutionRoleArn" do
+          expect(resource["Properties"]["ExecutionRoleArn"]).to eq({"Ref"=>"ExecutionRole"})
+      end
+      
+      it "to have property Tags" do
+          expect(resource["Properties"]["Tags"]).to eq([{"Key"=>"Name", "Value"=>"fargatev2Task"}, {"Key"=>"Environment", "Value"=>{"Ref"=>"EnvironmentName"}}, {"Key"=>"EnvironmentType", "Value"=>{"Ref"=>"EnvironmentType"}}])
+      end
+      
+    end
+    
   end
 
 end

--- a/spec/security_groups_spec.rb
+++ b/spec/security_groups_spec.rb
@@ -1,81 +1,304 @@
 require 'yaml'
 
-describe 'compiled component' do
+describe 'compiled component fargate-v2' do
   
   context 'cftest' do
     it 'compiles test' do
       expect(system("cfhighlander cftest #{@validate} --tests tests/security_groups.test.yaml")).to be_truthy
     end      
   end
-
+  
   let(:template) { YAML.load_file("#{File.dirname(__FILE__)}/../out/tests/security_groups/fargate-v2.compiled.yaml") }
-
-  context 'Resource SecurityGroup Source Security Group Ingress' do
-
-    let(:ingress) { template["Resources"]["IngressRule1"]["Properties"] }
   
-    it 'has property Properties' do
-      expect(ingress).to eq({
-        "Description"=>"allows traffic from an existing SG to this service",
-        "FromPort"=>80,
-        "GroupId"=>{"Ref"=>"SecurityGroup"}, 
-        "IpProtocol"=>"tcp", 
-        "SourceSecurityGroupId"=>{"Ref"=>"MySecurityGroup"}, 
-        "ToPort"=>80
-      })
+  context "Resource" do
+
+    
+    context "SecurityGroup" do
+      let(:resource) { template["Resources"]["SecurityGroup"] }
+
+      it "is of type AWS::EC2::SecurityGroup" do
+          expect(resource["Type"]).to eq("AWS::EC2::SecurityGroup")
+      end
+      
+      it "to have property VpcId" do
+          expect(resource["Properties"]["VpcId"]).to eq({"Ref"=>"VPCId"})
+      end
+      
+      it "to have property GroupDescription" do
+          expect(resource["Properties"]["GroupDescription"]).to eq("fargate-v2 fargate service")
+      end
+      
     end
+    
+    context "IngressRule1" do
+      let(:resource) { template["Resources"]["IngressRule1"] }
 
-  end
-
-  context 'Resource SecurityGroup Dest Security Group Ingress' do
-
-    let(:ingress) { template["Resources"]["IngressRule2"]["Properties"] }
-  
-    it 'has property Properties' do
-      expect(ingress).to eq({
-        "Description"=>"allows traffic from this service to another SG",
-        "FromPort"=>1433, 
-        "GroupId"=>{"Ref"=>"OtherSecurityGroup"}, 
-        "IpProtocol"=>"tcp", 
-        "SourceSecurityGroupId"=>{"Ref"=>"SecurityGroup"}, 
-        "ToPort"=>1433
-      })
+      it "is of type AWS::EC2::SecurityGroupIngress" do
+          expect(resource["Type"]).to eq("AWS::EC2::SecurityGroupIngress")
+      end
+      
+      it "to have property Description" do
+          expect(resource["Properties"]["Description"]).to eq("allows traffic from an existing SG to this service")
+      end
+      
+      it "to have property SourceSecurityGroupId" do
+          expect(resource["Properties"]["SourceSecurityGroupId"]).to eq({"Ref"=>"MySecurityGroup"})
+      end
+      
+      it "to have property GroupId" do
+          expect(resource["Properties"]["GroupId"]).to eq({"Ref"=>"SecurityGroup"})
+      end
+      
+      it "to have property IpProtocol" do
+          expect(resource["Properties"]["IpProtocol"]).to eq("tcp")
+      end
+      
+      it "to have property FromPort" do
+          expect(resource["Properties"]["FromPort"]).to eq(80)
+      end
+      
+      it "to have property ToPort" do
+          expect(resource["Properties"]["ToPort"]).to eq(80)
+      end
+      
     end
+    
+    context "IngressRule2" do
+      let(:resource) { template["Resources"]["IngressRule2"] }
 
-  end
-
-  context 'Resource SecurityGroup Dest Security Group Ingress' do
-
-    let(:ingress) { template["Resources"]["IngressRule3"]["Properties"] }
-  
-    it 'has property Properties' do
-      expect(ingress).to eq({
-        "Description"=>"allows traffic from one SG to another",
-        "FromPort"=>1024, 
-        "GroupId"=>{"Ref"=>"SecurityGroup"}, 
-        "IpProtocol"=>"tcp", 
-        "SourceSecurityGroupId"=>{"Ref"=>"MySecurityGroup"}, 
-        "ToPort"=>9999
-      })
+      it "is of type AWS::EC2::SecurityGroupIngress" do
+          expect(resource["Type"]).to eq("AWS::EC2::SecurityGroupIngress")
+      end
+      
+      it "to have property Description" do
+          expect(resource["Properties"]["Description"]).to eq("allows traffic from this service to another SG")
+      end
+      
+      it "to have property SourceSecurityGroupId" do
+          expect(resource["Properties"]["SourceSecurityGroupId"]).to eq({"Ref"=>"SecurityGroup"})
+      end
+      
+      it "to have property GroupId" do
+          expect(resource["Properties"]["GroupId"]).to eq({"Ref"=>"OtherSecurityGroup"})
+      end
+      
+      it "to have property IpProtocol" do
+          expect(resource["Properties"]["IpProtocol"]).to eq("tcp")
+      end
+      
+      it "to have property FromPort" do
+          expect(resource["Properties"]["FromPort"]).to eq(1433)
+      end
+      
+      it "to have property ToPort" do
+          expect(resource["Properties"]["ToPort"]).to eq(1433)
+      end
+      
     end
+    
+    context "IngressRule3" do
+      let(:resource) { template["Resources"]["IngressRule3"] }
 
-  end
-
-  context 'Resource SecurityGroup Inbound SSH From CIDR' do
-
-    let(:ingress) { template["Resources"]["IngressRule4"]["Properties"] }
-  
-    it 'has property Properties' do
-      expect(ingress).to eq({
-        "Description"=>"allow inbound 22 access from cidr",
-        "FromPort"=>22, 
-        "CidrIp"=>"10.0.0.1/32", 
-        "GroupId" => {"Ref"=>"SecurityGroup"},
-        "IpProtocol"=>"tcp", 
-        "ToPort"=>22
-      })
+      it "is of type AWS::EC2::SecurityGroupIngress" do
+          expect(resource["Type"]).to eq("AWS::EC2::SecurityGroupIngress")
+      end
+      
+      it "to have property Description" do
+          expect(resource["Properties"]["Description"]).to eq("allows traffic from one SG to another")
+      end
+      
+      it "to have property SourceSecurityGroupId" do
+          expect(resource["Properties"]["SourceSecurityGroupId"]).to eq({"Ref"=>"MySecurityGroup"})
+      end
+      
+      it "to have property GroupId" do
+          expect(resource["Properties"]["GroupId"]).to eq({"Ref"=>"SecurityGroup"})
+      end
+      
+      it "to have property IpProtocol" do
+          expect(resource["Properties"]["IpProtocol"]).to eq("tcp")
+      end
+      
+      it "to have property FromPort" do
+          expect(resource["Properties"]["FromPort"]).to eq(1024)
+      end
+      
+      it "to have property ToPort" do
+          expect(resource["Properties"]["ToPort"]).to eq(9999)
+      end
+      
     end
+    
+    context "IngressRule4" do
+      let(:resource) { template["Resources"]["IngressRule4"] }
 
+      it "is of type AWS::EC2::SecurityGroupIngress" do
+          expect(resource["Type"]).to eq("AWS::EC2::SecurityGroupIngress")
+      end
+      
+      it "to have property Description" do
+          expect(resource["Properties"]["Description"]).to eq("allow inbound 22 access from cidr")
+      end
+      
+      it "to have property CidrIp" do
+          expect(resource["Properties"]["CidrIp"]).to eq("10.0.0.1/32")
+      end
+      
+      it "to have property GroupId" do
+          expect(resource["Properties"]["GroupId"]).to eq({"Ref"=>"SecurityGroup"})
+      end
+      
+      it "to have property IpProtocol" do
+          expect(resource["Properties"]["IpProtocol"]).to eq("tcp")
+      end
+      
+      it "to have property FromPort" do
+          expect(resource["Properties"]["FromPort"]).to eq(22)
+      end
+      
+      it "to have property ToPort" do
+          expect(resource["Properties"]["ToPort"]).to eq(22)
+      end
+      
+    end
+    
+    context "EcsFargateService" do
+      let(:resource) { template["Resources"]["EcsFargateService"] }
+
+      it "is of type AWS::ECS::Service" do
+          expect(resource["Type"]).to eq("AWS::ECS::Service")
+      end
+      
+      it "to have property Cluster" do
+          expect(resource["Properties"]["Cluster"]).to eq({"Ref"=>"EcsCluster"})
+      end
+      
+      it "to have property DesiredCount" do
+          expect(resource["Properties"]["DesiredCount"]).to eq({"Ref"=>"DesiredCount"})
+      end
+      
+      it "to have property DeploymentConfiguration" do
+          expect(resource["Properties"]["DeploymentConfiguration"]).to eq({"MinimumHealthyPercent"=>{"Ref"=>"MinimumHealthyPercent"}, "MaximumPercent"=>{"Ref"=>"MaximumPercent"}})
+      end
+      
+      it "to have property EnableExecuteCommand" do
+          expect(resource["Properties"]["EnableExecuteCommand"]).to eq(false)
+      end
+      
+      it "to have property TaskDefinition" do
+          expect(resource["Properties"]["TaskDefinition"]).to eq({"Ref"=>"Task"})
+      end
+      
+      it "to have property LaunchType" do
+          expect(resource["Properties"]["LaunchType"]).to eq("FARGATE")
+      end
+      
+      it "to have property NetworkConfiguration" do
+          expect(resource["Properties"]["NetworkConfiguration"]).to eq({"AwsvpcConfiguration"=>{"AssignPublicIp"=>"DISABLED", "SecurityGroups"=>[{"Ref"=>"SecurityGroup"}], "Subnets"=>{"Ref"=>"SubnetIds"}}})
+      end
+      
+    end
+    
+    context "LogGroup" do
+      let(:resource) { template["Resources"]["LogGroup"] }
+
+      it "is of type AWS::Logs::LogGroup" do
+          expect(resource["Type"]).to eq("AWS::Logs::LogGroup")
+      end
+      
+      it "to have property LogGroupName" do
+          expect(resource["Properties"]["LogGroupName"]).to eq({"Ref"=>"AWS::StackName"})
+      end
+      
+      it "to have property RetentionInDays" do
+          expect(resource["Properties"]["RetentionInDays"]).to eq("7")
+      end
+      
+    end
+    
+    context "TaskRole" do
+      let(:resource) { template["Resources"]["TaskRole"] }
+
+      it "is of type AWS::IAM::Role" do
+          expect(resource["Type"]).to eq("AWS::IAM::Role")
+      end
+      
+      it "to have property AssumeRolePolicyDocument" do
+          expect(resource["Properties"]["AssumeRolePolicyDocument"]).to eq({"Version"=>"2012-10-17", "Statement"=>[{"Effect"=>"Allow", "Principal"=>{"Service"=>"ecs-tasks.amazonaws.com"}, "Action"=>"sts:AssumeRole"}, {"Effect"=>"Allow", "Principal"=>{"Service"=>"ssm.amazonaws.com"}, "Action"=>"sts:AssumeRole"}]})
+      end
+      
+      it "to have property Path" do
+          expect(resource["Properties"]["Path"]).to eq("/")
+      end
+      
+      it "to have property Policies" do
+          expect(resource["Properties"]["Policies"]).to eq([{"PolicyName"=>"fargate_default_policy", "PolicyDocument"=>{"Statement"=>[{"Sid"=>"fargatedefaultpolicy", "Action"=>["logs:GetLogEvents"], "Resource"=>[{"Fn::GetAtt"=>["LogGroup", "Arn"]}], "Effect"=>"Allow"}]}}])
+      end
+      
+    end
+    
+    context "ExecutionRole" do
+      let(:resource) { template["Resources"]["ExecutionRole"] }
+
+      it "is of type AWS::IAM::Role" do
+          expect(resource["Type"]).to eq("AWS::IAM::Role")
+      end
+      
+      it "to have property AssumeRolePolicyDocument" do
+          expect(resource["Properties"]["AssumeRolePolicyDocument"]).to eq({"Version"=>"2012-10-17", "Statement"=>[{"Effect"=>"Allow", "Principal"=>{"Service"=>"ecs-tasks.amazonaws.com"}, "Action"=>"sts:AssumeRole"}, {"Effect"=>"Allow", "Principal"=>{"Service"=>"ssm.amazonaws.com"}, "Action"=>"sts:AssumeRole"}]})
+      end
+      
+      it "to have property Path" do
+          expect(resource["Properties"]["Path"]).to eq("/")
+      end
+      
+      it "to have property ManagedPolicyArns" do
+          expect(resource["Properties"]["ManagedPolicyArns"]).to eq(["arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"])
+      end
+      
+    end
+    
+    context "Task" do
+      let(:resource) { template["Resources"]["Task"] }
+
+      it "is of type AWS::ECS::TaskDefinition" do
+          expect(resource["Type"]).to eq("AWS::ECS::TaskDefinition")
+      end
+      
+      it "to have property ContainerDefinitions" do
+          expect(resource["Properties"]["ContainerDefinitions"]).to eq([{"Name"=>"proxy", "Image"=>{"Fn::Join"=>["", ["", "nginx", ":", "latest"]]}, "LogConfiguration"=>{"LogDriver"=>"awslogs", "Options"=>{"awslogs-group"=>{"Ref"=>"LogGroup"}, "awslogs-region"=>{"Ref"=>"AWS::Region"}, "awslogs-stream-prefix"=>"proxy"}}}])
+      end
+      
+      it "to have property RequiresCompatibilities" do
+          expect(resource["Properties"]["RequiresCompatibilities"]).to eq(["FARGATE"])
+      end
+      
+      it "to have property Cpu" do
+          expect(resource["Properties"]["Cpu"]).to eq(256)
+      end
+      
+      it "to have property Memory" do
+          expect(resource["Properties"]["Memory"]).to eq(512)
+      end
+      
+      it "to have property NetworkMode" do
+          expect(resource["Properties"]["NetworkMode"]).to eq("awsvpc")
+      end
+      
+      it "to have property TaskRoleArn" do
+          expect(resource["Properties"]["TaskRoleArn"]).to eq({"Ref"=>"TaskRole"})
+      end
+      
+      it "to have property ExecutionRoleArn" do
+          expect(resource["Properties"]["ExecutionRoleArn"]).to eq({"Ref"=>"ExecutionRole"})
+      end
+      
+      it "to have property Tags" do
+          expect(resource["Properties"]["Tags"]).to eq([{"Key"=>"Name", "Value"=>"fargatev2Task"}, {"Key"=>"Environment", "Value"=>{"Ref"=>"EnvironmentName"}}, {"Key"=>"EnvironmentType", "Value"=>{"Ref"=>"EnvironmentType"}}])
+      end
+      
+    end
+    
   end
 
 end

--- a/spec/simple_spec.rb
+++ b/spec/simple_spec.rb
@@ -1,6 +1,6 @@
 require 'yaml'
 
-describe 'compiled component' do
+describe 'compiled component fargate-v2' do
   
   context 'cftest' do
     it 'compiles test' do
@@ -9,198 +9,168 @@ describe 'compiled component' do
   end
   
   let(:template) { YAML.load_file("#{File.dirname(__FILE__)}/../out/tests/simple/fargate-v2.compiled.yaml") }
+  
+  context "Resource" do
 
-  context 'Resource LogGroup' do
+    
+    context "SecurityGroup" do
+      let(:resource) { template["Resources"]["SecurityGroup"] }
 
-    let(:properties) { template["Resources"]["LogGroup"]["Properties"] }
-
-    it 'has property RetentionInDays' do
-      expect(properties["RetentionInDays"]).to eq('7')
+      it "is of type AWS::EC2::SecurityGroup" do
+          expect(resource["Type"]).to eq("AWS::EC2::SecurityGroup")
+      end
+      
+      it "to have property VpcId" do
+          expect(resource["Properties"]["VpcId"]).to eq({"Ref"=>"VPCId"})
+      end
+      
+      it "to have property GroupDescription" do
+          expect(resource["Properties"]["GroupDescription"]).to eq("fargate-v2 fargate service")
+      end
+      
     end
+    
+    context "EcsFargateService" do
+      let(:resource) { template["Resources"]["EcsFargateService"] }
 
-    it 'has property LogGroupName' do
-      expect(properties["LogGroupName"]).to eq({"Ref"=>"AWS::StackName"})
+      it "is of type AWS::ECS::Service" do
+          expect(resource["Type"]).to eq("AWS::ECS::Service")
+      end
+      
+      it "to have property Cluster" do
+          expect(resource["Properties"]["Cluster"]).to eq({"Ref"=>"EcsCluster"})
+      end
+      
+      it "to have property PlatformVersion" do
+          expect(resource["Properties"]["PlatformVersion"]).to eq("1.4.0")
+      end
+      
+      it "to have property DesiredCount" do
+          expect(resource["Properties"]["DesiredCount"]).to eq({"Ref"=>"DesiredCount"})
+      end
+      
+      it "to have property DeploymentConfiguration" do
+          expect(resource["Properties"]["DeploymentConfiguration"]).to eq({"MinimumHealthyPercent"=>{"Ref"=>"MinimumHealthyPercent"}, "MaximumPercent"=>{"Ref"=>"MaximumPercent"}})
+      end
+      
+      it "to have property EnableExecuteCommand" do
+          expect(resource["Properties"]["EnableExecuteCommand"]).to eq(false)
+      end
+      
+      it "to have property TaskDefinition" do
+          expect(resource["Properties"]["TaskDefinition"]).to eq({"Ref"=>"Task"})
+      end
+      
+      it "to have property LaunchType" do
+          expect(resource["Properties"]["LaunchType"]).to eq("FARGATE")
+      end
+      
+      it "to have property NetworkConfiguration" do
+          expect(resource["Properties"]["NetworkConfiguration"]).to eq({"AwsvpcConfiguration"=>{"AssignPublicIp"=>"DISABLED", "SecurityGroups"=>[{"Ref"=>"SecurityGroup"}], "Subnets"=>{"Ref"=>"SubnetIds"}}})
+      end
+      
     end
+    
+    context "LogGroup" do
+      let(:resource) { template["Resources"]["LogGroup"] }
 
+      it "is of type AWS::Logs::LogGroup" do
+          expect(resource["Type"]).to eq("AWS::Logs::LogGroup")
+      end
+      
+      it "to have property LogGroupName" do
+          expect(resource["Properties"]["LogGroupName"]).to eq({"Ref"=>"AWS::StackName"})
+      end
+      
+      it "to have property RetentionInDays" do
+          expect(resource["Properties"]["RetentionInDays"]).to eq("7")
+      end
+      
+    end
+    
+    context "TaskRole" do
+      let(:resource) { template["Resources"]["TaskRole"] }
+
+      it "is of type AWS::IAM::Role" do
+          expect(resource["Type"]).to eq("AWS::IAM::Role")
+      end
+      
+      it "to have property AssumeRolePolicyDocument" do
+          expect(resource["Properties"]["AssumeRolePolicyDocument"]).to eq({"Version"=>"2012-10-17", "Statement"=>[{"Effect"=>"Allow", "Principal"=>{"Service"=>"ecs-tasks.amazonaws.com"}, "Action"=>"sts:AssumeRole"}, {"Effect"=>"Allow", "Principal"=>{"Service"=>"ssm.amazonaws.com"}, "Action"=>"sts:AssumeRole"}]})
+      end
+      
+      it "to have property Path" do
+          expect(resource["Properties"]["Path"]).to eq("/")
+      end
+      
+      it "to have property Policies" do
+          expect(resource["Properties"]["Policies"]).to eq([{"PolicyName"=>"fargate_default_policy", "PolicyDocument"=>{"Statement"=>[{"Sid"=>"fargatedefaultpolicy", "Action"=>["logs:GetLogEvents"], "Resource"=>[{"Fn::GetAtt"=>["LogGroup", "Arn"]}], "Effect"=>"Allow"}]}}])
+      end
+      
+    end
+    
+    context "ExecutionRole" do
+      let(:resource) { template["Resources"]["ExecutionRole"] }
+
+      it "is of type AWS::IAM::Role" do
+          expect(resource["Type"]).to eq("AWS::IAM::Role")
+      end
+      
+      it "to have property AssumeRolePolicyDocument" do
+          expect(resource["Properties"]["AssumeRolePolicyDocument"]).to eq({"Version"=>"2012-10-17", "Statement"=>[{"Effect"=>"Allow", "Principal"=>{"Service"=>"ecs-tasks.amazonaws.com"}, "Action"=>"sts:AssumeRole"}, {"Effect"=>"Allow", "Principal"=>{"Service"=>"ssm.amazonaws.com"}, "Action"=>"sts:AssumeRole"}]})
+      end
+      
+      it "to have property Path" do
+          expect(resource["Properties"]["Path"]).to eq("/")
+      end
+      
+      it "to have property ManagedPolicyArns" do
+          expect(resource["Properties"]["ManagedPolicyArns"]).to eq(["arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"])
+      end
+      
+    end
+    
+    context "Task" do
+      let(:resource) { template["Resources"]["Task"] }
+
+      it "is of type AWS::ECS::TaskDefinition" do
+          expect(resource["Type"]).to eq("AWS::ECS::TaskDefinition")
+      end
+      
+      it "to have property ContainerDefinitions" do
+          expect(resource["Properties"]["ContainerDefinitions"]).to eq([{"Name"=>"proxy", "Image"=>{"Fn::Join"=>["", ["", "nginx", ":", "latest"]]}, "LogConfiguration"=>{"LogDriver"=>"awslogs", "Options"=>{"awslogs-group"=>{"Ref"=>"LogGroup"}, "awslogs-region"=>{"Ref"=>"AWS::Region"}, "awslogs-stream-prefix"=>"proxy"}}}])
+      end
+      
+      it "to have property RequiresCompatibilities" do
+          expect(resource["Properties"]["RequiresCompatibilities"]).to eq(["FARGATE"])
+      end
+      
+      it "to have property Cpu" do
+          expect(resource["Properties"]["Cpu"]).to eq(256)
+      end
+      
+      it "to have property Memory" do
+          expect(resource["Properties"]["Memory"]).to eq(512)
+      end
+      
+      it "to have property NetworkMode" do
+          expect(resource["Properties"]["NetworkMode"]).to eq("awsvpc")
+      end
+      
+      it "to have property TaskRoleArn" do
+          expect(resource["Properties"]["TaskRoleArn"]).to eq({"Ref"=>"TaskRole"})
+      end
+      
+      it "to have property ExecutionRoleArn" do
+          expect(resource["Properties"]["ExecutionRoleArn"]).to eq({"Ref"=>"ExecutionRole"})
+      end
+      
+      it "to have property Tags" do
+          expect(resource["Properties"]["Tags"]).to eq([{"Key"=>"Name", "Value"=>"fargatev2Task"}, {"Key"=>"Environment", "Value"=>{"Ref"=>"EnvironmentName"}}, {"Key"=>"EnvironmentType", "Value"=>{"Ref"=>"EnvironmentType"}}])
+      end
+      
+    end
+    
   end
-
-  context 'Resource Task' do
-
-    let(:properties) { template["Resources"]["Task"]["Properties"] }
-    let(:containerDefinition) { template["Resources"]["Task"]["Properties"]['ContainerDefinitions'][0] }
-
-    it 'has property RequiresCompatibilities' do
-      expect(properties["RequiresCompatibilities"]).to eq(['FARGATE'])
-    end
-
-    it 'has property CPU' do
-      expect(properties["Cpu"]).to eq(256)
-    end
-
-    it 'has property Memory' do
-      expect(properties["Memory"]).to eq(512)
-    end
-
-    it 'has property NetworkMode' do
-      expect(properties["NetworkMode"]).to eq("awsvpc")
-    end
-
-    it 'has property Tags' do
-      expect(properties["Tags"]).to eq([
-        {"Key"=>"Name", "Value"=>"fargatev2Task"}, 
-        {"Key"=>"Environment", "Value"=>{"Ref"=>"EnvironmentName"}}, 
-        {"Key"=>"EnvironmentType", "Value"=>{"Ref"=>"EnvironmentType"}}])
-    end
-
-    it 'has ContainerDefinition Name' do
-      expect(containerDefinition["Name"]).to eq("proxy")
-    end
-
-    it 'has ContainerDefinition Image' do
-      expect(containerDefinition["Image"]).to eq({"Fn::Join"=>["", ["", "nginx", ":", "latest"]]})
-    end
-
-    it 'has ContainerDefinition LogConfiguration' do
-      expect(containerDefinition["LogConfiguration"]["LogDriver"]).to eq("awslogs")
-      expect(containerDefinition["LogConfiguration"]["Options"]).to eq({
-        "awslogs-group" => {"Ref"=>"LogGroup"},
-        "awslogs-region" => {"Ref"=>"AWS::Region"},
-        "awslogs-stream-prefix" => "proxy"
-      })
-
-    end
-
-  end
-
-  context 'Resource Security Group' do
-
-    let(:properties) { template["Resources"]["SecurityGroup"]["Properties"] }
-
-    it 'has property VpcId' do
-      expect(properties["VpcId"]).to eq({"Ref"=>"VPCId"})
-    end
-
-    it 'has property GroupDescription' do
-      expect(properties["GroupDescription"]).to eq("fargate-v2 fargate service")
-    end
-
-  end
-
-  context 'Resource ExecutionRole' do
-
-    let(:properties) { template["Resources"]["ExecutionRole"]['Properties'] }
-
-    it 'has ManagedPolicyArns' do
-      expect(properties["ManagedPolicyArns"]).to eq(["arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"])
-    end
-
-    it 'has AssumeRolePolicyDocument' do
-      expect(properties["AssumeRolePolicyDocument"]).to eq({
-        "Statement"=>[
-          {
-            "Action"=>"sts:AssumeRole", 
-            "Effect"=>"Allow", 
-            "Principal"=>{"Service"=>"ecs-tasks.amazonaws.com"}
-          },
-          {
-            "Action"=>"sts:AssumeRole", 
-            "Effect"=>"Allow", 
-            "Principal"=>{"Service"=>"ssm.amazonaws.com"}
-          }
-        ], 
-        "Version"=>"2012-10-17"
-      })
-    end
-
-  end
-
-  context 'Resource TaskRole' do
-
-    let(:properties) { template["Resources"]["TaskRole"]['Properties'] }
-
-    it 'has AssumeRolePolicyDocument' do
-      expect(properties["AssumeRolePolicyDocument"]).to eq({
-        "Version" => "2012-10-17",
-        "Statement" => [
-          {
-            "Action"=>"sts:AssumeRole",
-            "Effect"=>"Allow",
-            "Principal"=>{"Service"=>"ecs-tasks.amazonaws.com"}
-          },
-          {
-            "Action"=>"sts:AssumeRole",
-            "Effect"=>"Allow",
-            "Principal"=>{"Service"=>"ssm.amazonaws.com"}
-          }
-        ],
-      })
-    end
-
-    it 'has Polices' do
-      expect(properties["Policies"]).to eq([{
-        "PolicyDocument"=>{
-          "Statement"=>[{
-            "Action"=>["logs:GetLogEvents"],
-            "Effect"=>"Allow",
-            "Resource"=>[{"Fn::GetAtt"=>["LogGroup", "Arn"]}],
-            "Sid"=>"fargatedefaultpolicy"}
-          ]},
-          "PolicyName"=>"fargate_default_policy"
-        }]
-      )
-    end
-
-  end
-
-  context 'Resource Service' do
-
-    let(:properties) { template["Resources"]["EcsFargateService"]["Properties"] }
-
-    it 'has property Cluster' do
-      expect(properties["Cluster"]).to eq({"Ref"=>"EcsCluster"})
-    end
-
-    it 'has property LaunchType' do
-      expect(properties["LaunchType"]).to eq("FARGATE")
-    end
-
-    it 'has property DesiredCount' do
-      expect(properties["DesiredCount"]).to eq({"Ref"=>"DesiredCount"})
-    end
-
-    it 'has property DeploymentConfiguration' do
-      expect(properties["DeploymentConfiguration"]).to eq({
-        "MaximumPercent"=>{"Ref"=>"MaximumPercent"}, 
-        "MinimumHealthyPercent"=>{"Ref"=>"MinimumHealthyPercent"}
-      })
-    end
-
-    it 'has property TaskDefinition' do
-      expect(properties["TaskDefinition"]).to eq({"Ref"=>"Task"})
-    end
-
-    it 'has property NetworkConfiguration' do
-      expect(properties["NetworkConfiguration"]).to eq({
-        "AwsvpcConfiguration"=>{
-          "AssignPublicIp"=>"DISABLED", 
-          "SecurityGroups"=>[{"Ref"=>"SecurityGroup"}], 
-          "Subnets"=>{"Ref"=>"SubnetIds"}
-        }
-      })
-    end
-
-  end
-
-  context 'Resource Outputs' do
-
-    let(:outputs) { template["Outputs"] }
-
-    it 'has component_name as part of the export' do
-      expect(outputs['EcsTaskArn']).to eq({
-        "Export"=>{"Name"=>{"Fn::Sub"=>"${EnvironmentName}-fargatev2Task-EcsTaskArn"}},
-        "Value"=>{"Ref"=>"Task"}
-      })
-    end
-  end 
 
 end

--- a/spec/targetgroup_healthcheck_spec.rb
+++ b/spec/targetgroup_healthcheck_spec.rb
@@ -91,7 +91,7 @@ describe 'compiled component fargate-v2' do
       end
       
       it "to have property Actions" do
-          expect(resource["Properties"]["Actions"]).to eq([{"Type"=>"forward", "TargetGroupArn"=>{"Ref"=>"TaskTargetGroup"}}])
+          expect(resource["Properties"]["Actions"]).to eq({"Fn::If"=>["EnableCognito", [{"Type"=>"forward", "Order"=>5000, "TargetGroupArn"=>{"Ref"=>"TaskTargetGroup"}}, {"Type"=>"authenticate-cognito", "Order"=>1, "AuthenticateCognitoConfig"=>{"UserPoolArn"=>{"Ref"=>"UserPoolId"}, "UserPoolClientId"=>{"Ref"=>"UserPoolClientId"}, "UserPoolDomain"=>{"Ref"=>"UserPoolDomainName"}}}], [{"Type"=>"forward", "Order"=>5000, "TargetGroupArn"=>{"Ref"=>"TaskTargetGroup"}}]]})
       end
       
       it "to have property Conditions" do

--- a/spec/targetgroup_param_spec.rb
+++ b/spec/targetgroup_param_spec.rb
@@ -1,42 +1,176 @@
 require 'yaml'
 
-describe 'compiled component' do
+describe 'compiled component fargate-v2' do
   
   context 'cftest' do
     it 'compiles test' do
       expect(system("cfhighlander cftest #{@validate} --tests tests/targetgroup_param.test.yaml")).to be_truthy
     end      
   end
-
+  
   let(:template) { YAML.load_file("#{File.dirname(__FILE__)}/../out/tests/targetgroup_param/fargate-v2.compiled.yaml") }
+  
+  context "Resource" do
 
-  context 'check template parameters' do
     
-    let(:parameters) { template["Parameters"] }
+    context "SecurityGroup" do
+      let(:resource) { template["Resources"]["SecurityGroup"] }
 
-    it 'has load balancer params' do
-      expect(parameters).to include({
-        "LoadBalancer" => {"Default"=>"", "NoEcho"=>false, "Type"=>"String"},
-        "DnsDomain" => {"Default"=>"", "NoEcho"=>false, "Type"=>"String"},
-        "Listener" => {"Default"=>"", "NoEcho"=>false, "Type"=>"String"},
-        "TargetGroup" => {"Default"=>"", "NoEcho"=>false, "Type"=>"String"}
-      })
-    end
-
-    context 'Resource TargetRule' do
-
-      let(:loadbalancer) { template["Resources"]["EcsFargateService"]["Properties"]["LoadBalancers"] }
-  
-      it 'has property Properties' do
-        expect(loadbalancer).to eq([{
-          "ContainerName"=>"nginx", 
-          "ContainerPort"=>80, 
-          "TargetGroupArn"=>{"Ref"=>"TargetGroup"}
-        }])
+      it "is of type AWS::EC2::SecurityGroup" do
+          expect(resource["Type"]).to eq("AWS::EC2::SecurityGroup")
       end
-  
+      
+      it "to have property VpcId" do
+          expect(resource["Properties"]["VpcId"]).to eq({"Ref"=>"VPCId"})
+      end
+      
+      it "to have property GroupDescription" do
+          expect(resource["Properties"]["GroupDescription"]).to eq("fargate-v2 fargate service")
+      end
+      
     end
+    
+    context "EcsFargateService" do
+      let(:resource) { template["Resources"]["EcsFargateService"] }
 
+      it "is of type AWS::ECS::Service" do
+          expect(resource["Type"]).to eq("AWS::ECS::Service")
+      end
+      
+      it "to have property Cluster" do
+          expect(resource["Properties"]["Cluster"]).to eq({"Ref"=>"EcsCluster"})
+      end
+      
+      it "to have property DesiredCount" do
+          expect(resource["Properties"]["DesiredCount"]).to eq({"Ref"=>"DesiredCount"})
+      end
+      
+      it "to have property DeploymentConfiguration" do
+          expect(resource["Properties"]["DeploymentConfiguration"]).to eq({"MinimumHealthyPercent"=>{"Ref"=>"MinimumHealthyPercent"}, "MaximumPercent"=>{"Ref"=>"MaximumPercent"}})
+      end
+      
+      it "to have property EnableExecuteCommand" do
+          expect(resource["Properties"]["EnableExecuteCommand"]).to eq(false)
+      end
+      
+      it "to have property TaskDefinition" do
+          expect(resource["Properties"]["TaskDefinition"]).to eq({"Ref"=>"Task"})
+      end
+      
+      it "to have property LaunchType" do
+          expect(resource["Properties"]["LaunchType"]).to eq("FARGATE")
+      end
+      
+      it "to have property LoadBalancers" do
+          expect(resource["Properties"]["LoadBalancers"]).to eq([{"ContainerName"=>"nginx", "ContainerPort"=>80, "TargetGroupArn"=>{"Ref"=>"TargetGroup"}}])
+      end
+      
+      it "to have property NetworkConfiguration" do
+          expect(resource["Properties"]["NetworkConfiguration"]).to eq({"AwsvpcConfiguration"=>{"AssignPublicIp"=>"DISABLED", "SecurityGroups"=>[{"Ref"=>"SecurityGroup"}], "Subnets"=>{"Ref"=>"SubnetIds"}}})
+      end
+      
+    end
+    
+    context "LogGroup" do
+      let(:resource) { template["Resources"]["LogGroup"] }
+
+      it "is of type AWS::Logs::LogGroup" do
+          expect(resource["Type"]).to eq("AWS::Logs::LogGroup")
+      end
+      
+      it "to have property LogGroupName" do
+          expect(resource["Properties"]["LogGroupName"]).to eq({"Ref"=>"AWS::StackName"})
+      end
+      
+      it "to have property RetentionInDays" do
+          expect(resource["Properties"]["RetentionInDays"]).to eq("7")
+      end
+      
+    end
+    
+    context "TaskRole" do
+      let(:resource) { template["Resources"]["TaskRole"] }
+
+      it "is of type AWS::IAM::Role" do
+          expect(resource["Type"]).to eq("AWS::IAM::Role")
+      end
+      
+      it "to have property AssumeRolePolicyDocument" do
+          expect(resource["Properties"]["AssumeRolePolicyDocument"]).to eq({"Version"=>"2012-10-17", "Statement"=>[{"Effect"=>"Allow", "Principal"=>{"Service"=>"ecs-tasks.amazonaws.com"}, "Action"=>"sts:AssumeRole"}, {"Effect"=>"Allow", "Principal"=>{"Service"=>"ssm.amazonaws.com"}, "Action"=>"sts:AssumeRole"}]})
+      end
+      
+      it "to have property Path" do
+          expect(resource["Properties"]["Path"]).to eq("/")
+      end
+      
+      it "to have property Policies" do
+          expect(resource["Properties"]["Policies"]).to eq([{"PolicyName"=>"fargate_default_policy", "PolicyDocument"=>{"Statement"=>[{"Sid"=>"fargatedefaultpolicy", "Action"=>["logs:GetLogEvents"], "Resource"=>[{"Fn::GetAtt"=>["LogGroup", "Arn"]}], "Effect"=>"Allow"}]}}])
+      end
+      
+    end
+    
+    context "ExecutionRole" do
+      let(:resource) { template["Resources"]["ExecutionRole"] }
+
+      it "is of type AWS::IAM::Role" do
+          expect(resource["Type"]).to eq("AWS::IAM::Role")
+      end
+      
+      it "to have property AssumeRolePolicyDocument" do
+          expect(resource["Properties"]["AssumeRolePolicyDocument"]).to eq({"Version"=>"2012-10-17", "Statement"=>[{"Effect"=>"Allow", "Principal"=>{"Service"=>"ecs-tasks.amazonaws.com"}, "Action"=>"sts:AssumeRole"}, {"Effect"=>"Allow", "Principal"=>{"Service"=>"ssm.amazonaws.com"}, "Action"=>"sts:AssumeRole"}]})
+      end
+      
+      it "to have property Path" do
+          expect(resource["Properties"]["Path"]).to eq("/")
+      end
+      
+      it "to have property ManagedPolicyArns" do
+          expect(resource["Properties"]["ManagedPolicyArns"]).to eq(["arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"])
+      end
+      
+    end
+    
+    context "Task" do
+      let(:resource) { template["Resources"]["Task"] }
+
+      it "is of type AWS::ECS::TaskDefinition" do
+          expect(resource["Type"]).to eq("AWS::ECS::TaskDefinition")
+      end
+      
+      it "to have property ContainerDefinitions" do
+          expect(resource["Properties"]["ContainerDefinitions"]).to eq([{"Name"=>"proxy", "Image"=>{"Fn::Join"=>["", ["", "nginx", ":", "latest"]]}, "LogConfiguration"=>{"LogDriver"=>"awslogs", "Options"=>{"awslogs-group"=>{"Ref"=>"LogGroup"}, "awslogs-region"=>{"Ref"=>"AWS::Region"}, "awslogs-stream-prefix"=>"proxy"}}, "PortMappings"=>[{"ContainerPort"=>80}]}])
+      end
+      
+      it "to have property RequiresCompatibilities" do
+          expect(resource["Properties"]["RequiresCompatibilities"]).to eq(["FARGATE"])
+      end
+      
+      it "to have property Cpu" do
+          expect(resource["Properties"]["Cpu"]).to eq(256)
+      end
+      
+      it "to have property Memory" do
+          expect(resource["Properties"]["Memory"]).to eq(512)
+      end
+      
+      it "to have property NetworkMode" do
+          expect(resource["Properties"]["NetworkMode"]).to eq("awsvpc")
+      end
+      
+      it "to have property TaskRoleArn" do
+          expect(resource["Properties"]["TaskRoleArn"]).to eq({"Ref"=>"TaskRole"})
+      end
+      
+      it "to have property ExecutionRoleArn" do
+          expect(resource["Properties"]["ExecutionRoleArn"]).to eq({"Ref"=>"ExecutionRole"})
+      end
+      
+      it "to have property Tags" do
+          expect(resource["Properties"]["Tags"]).to eq([{"Key"=>"Name", "Value"=>"fargatev2Task"}, {"Key"=>"Environment", "Value"=>{"Ref"=>"EnvironmentName"}}, {"Key"=>"EnvironmentType", "Value"=>{"Ref"=>"EnvironmentType"}}])
+      end
+      
+    end
+    
   end
 
 end


### PR DESCRIPTION
Added cognito support to ALB component.

Cognito is enabled by provisioning the `cognitio` component and adding the parameter `cognito:true` to a target group. The a new listener rule for cognito will then be created alongside the other defined rules. 

Note - Atleast one other rule must be defined

Target Group Example 
```
targetgroup:
-
  name: default
  protocol: http
  cognito: true
  container: nginx
  port: 80
  rules:
    -  
      priority: 10
      path: /v1
